### PR TITLE
Implementation of CP Decomposition

### DIFF
--- a/src/include/einsums/Decomposition.hpp
+++ b/src/include/einsums/Decomposition.hpp
@@ -7,10 +7,6 @@
 #include <cmath>
 #include <functional>
 
-using namespace einsums;
-using namespace einsums::tensor_algebra;
-using namespace einsums::tensor_algebra::index;
-
 namespace einsums::decomposition {
 
 template <size_t TRank>
@@ -121,6 +117,9 @@ auto initialize_cp(std::vector<Tensor<2, TType>> &folds, size_t rank) -> std::ve
  */
 template <template <size_t, typename> typename TTensor, size_t TRank, typename TType = double>
 auto parafac(const TTensor<TRank, TType> &tensor, size_t rank, int n_iter_max = 100, double tolerance = 1.e-8) -> std::vector<Tensor<2, TType>> {
+
+    using namespace einsums::tensor_algebra;
+    using namespace einsums::tensor_algebra::index;
 
     // Compute set of unfolded matrices
     std::vector<Tensor<2, TType>> unfolded_matrices;

--- a/src/include/einsums/Decomposition.hpp
+++ b/src/include/einsums/Decomposition.hpp
@@ -34,6 +34,74 @@ auto validate_cp_rank(const Dim<TRank> shape, const std::string &rounding = "rou
     return static_cast<int>(rounding_func(prod / sum));
 }
 
+/**
+ * Computes the RMSD between two tensors of arbitrary dimension
+ */
+template <template <size_t, typename> typename TTensor, size_t TRank, typename TType = double>
+auto rmsd(const TTensor<TRank, TType> &tensor1, const TTensor<TRank, TType> &tensor2) -> TType {
+    TType diff = 0.0;
+    auto target_dims = get_dim_ranges<TRank>(tensor1);
+
+    size_t nelem = 0;
+    for (auto target_combination : std::apply(ranges::views::cartesian_product, target_dims)) {
+        TType target1 = std::apply(tensor1, target_combination);
+        TType target2 = std::apply(tensor2, target_combination);
+        diff += (target1 - target2)*(target1 - target2);
+        nelem += 1;
+    }
+
+    return std::sqrt(diff / nelem);
+}
+
+/**
+ * Reconstructs a tensor given a CANDECOMP/PARAFAC decomposition
+ * 
+ *   factors = The decomposed CANDECOMP matrices (dimension: [dim[i], rank])
+ */
+template <size_t TRank, typename TType = double>
+auto parafac_reconstruct(const std::vector<Tensor<2, TType>>& factors) -> Tensor<TRank, TType> {
+
+    size_t rank = 0;
+    size_t tensor_size;
+    Dim<TRank> dims;
+    std::vector<size_t> offsets_per_dim;
+
+    size_t i = 0;
+    for (const auto& factor : factors) {
+        dims[i] = factor.dim(0);
+        if (!rank) rank = factor.dim(1);
+        i++;
+    }
+
+    offsets_per_dim.resize(TRank);
+    size_t offset = 1;
+    for (size_t n = 0; n < TRank; n++) {
+        size_t m = TRank - n - 1;
+        offsets_per_dim[m] = offset;
+        offset *= dims[m];
+    }
+    tensor_size = offset;
+
+    Tensor<TRank, TType> new_tensor(dims);
+    new_tensor.zero();
+
+    auto indices = get_dim_ranges<TRank>(new_tensor);
+
+    for (auto idx_combo : std::apply(ranges::views::cartesian_product, indices)) {
+        TType &target = std::apply(new_tensor, idx_combo);
+        for (size_t r = 0; r < rank; r++) {
+            double temp = 1.0;
+            for_sequence<TRank>([&](auto n) {
+                temp *= factors[n](std::get<n>(idx_combo), r);
+            });
+            target += temp;
+        }
+    }
+
+    return new_tensor;
+
+}
+
 template <template <size_t, typename> typename TTensor, size_t TRank, typename TType = double>
 auto initialize_cp(const TTensor<TRank, TType> &tensor, size_t rank) -> std::vector<Tensor<2, TType>> {
 
@@ -140,7 +208,7 @@ auto parafac(const TTensor<TRank, TType> &tensor, size_t rank, int n_iter_max = 
 
             // Step 1: Matrix Multiplication
             einsum(0.0, Indices{r, I}, &fcopy,
-                   1.0, Indices{I, K}, unfolded_matrices[n_ind], Indices{K, r}, KRs[KRs.size() - 1]);
+                   1.0, Indices{I, K}, unfolded_matrices[n_ind], Indices{K, r}, KRs.back());
 
             // Step 2: Linear Solving (instead of inversion, for numerical stability)
             linear_algebra::gesv(&V, &fcopy);
@@ -152,8 +220,9 @@ auto parafac(const TTensor<TRank, TType> &tensor, size_t rank, int n_iter_max = 
             einsum(0.0, Indices{I, r}, &factors[n_ind], 
                    1.0, Indices{r, I}, fcopy, Indices{r, I}, ones);
 
-            println(factors[n_ind]);
+            // println(factors[n_ind]);
             */
+            
             size_t ndim = tensor.dim(n_ind);
             Tensor<2, TType> fcopy{"fcopy", ndim, rank};
 

--- a/src/include/einsums/Decomposition.hpp
+++ b/src/include/einsums/Decomposition.hpp
@@ -60,11 +60,8 @@ auto rmsd(const TTensor<TRank, TType> &tensor1, const TTensor<TRank, TType> &ten
  */
 template <size_t TRank, typename TType = double>
 auto parafac_reconstruct(const std::vector<Tensor<2, TType>>& factors) -> Tensor<TRank, TType> {
-
     size_t rank = 0;
-    size_t tensor_size;
     Dim<TRank> dims;
-    std::vector<size_t> offsets_per_dim;
 
     size_t i = 0;
     for (const auto& factor : factors) {
@@ -72,15 +69,6 @@ auto parafac_reconstruct(const std::vector<Tensor<2, TType>>& factors) -> Tensor
         if (!rank) rank = factor.dim(1);
         i++;
     }
-
-    offsets_per_dim.resize(TRank);
-    size_t offset = 1;
-    for (size_t n = 0; n < TRank; n++) {
-        size_t m = TRank - n - 1;
-        offsets_per_dim[m] = offset;
-        offset *= dims[m];
-    }
-    tensor_size = offset;
 
     Tensor<TRank, TType> new_tensor(dims);
     new_tensor.zero();
@@ -99,7 +87,6 @@ auto parafac_reconstruct(const std::vector<Tensor<2, TType>>& factors) -> Tensor
     }
 
     return new_tensor;
-
 }
 
 template <size_t TRank, typename TType = double>
@@ -143,7 +130,7 @@ auto parafac(const TTensor<TRank, TType> &tensor, size_t rank, int n_iter_max = 
 
     // Perform SVD guess for parafac decomposition procedure
     std::vector<Tensor<2, TType>> factors = initialize_cp<TRank, TType>(unfolded_matrices, rank);
-    
+
     // Keep track of previous factors (for tracking convergence)
     std::vector<Tensor<2, TType>> prev_factors;
     for_sequence<TRank>([&](auto i) {
@@ -151,11 +138,11 @@ auto parafac(const TTensor<TRank, TType> &tensor, size_t rank, int n_iter_max = 
     });
 
     int iter = 0;
-    // bool converged = false;
+    bool converged = false;
     while (iter < n_iter_max) {
         for_sequence<TRank>([&](auto n_ind) {
             // Update prev factors
-            // prev_factors[n_ind] = factors[n_ind];
+            prev_factors[n_ind] = factors[n_ind];
 
             // Form V and Khatri-Rao product intermediates
             Tensor<2, TType> V;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,6 +4,7 @@ add_executable(test-all
     LinearAlgebra.cpp
     Tensor.cpp
     TensorAlgebra.cpp
+    Decomposition.cpp
     )
 target_link_libraries(test-all Catch2::Catch2 einsums)
 # catch_discover_tests(test-tensoralgebra

--- a/tests/Decomposition.cpp
+++ b/tests/Decomposition.cpp
@@ -1,0 +1,19 @@
+#include "einsums/Decomposition.hpp"
+
+#include "einsums/Tensor.hpp"
+#include "einsums/TensorAlgebra.hpp"
+#include "einsums/LinearAlgebra.hpp"
+
+#include <catch2/catch.hpp>
+
+TEST_CASE("CP 1") {
+    using namespace einsums;
+    using namespace einsums::tensor_algebra;
+    using namespace einsums::decomposition;
+
+    Tensor<3, double> I_rand = create_random_tensor("I_rand", 3, 4, 2);
+
+    println(I_rand);
+
+    auto factors = parafac(I_rand, 2, 10, 1.0e-6);
+}

--- a/tests/Decomposition.cpp
+++ b/tests/Decomposition.cpp
@@ -23,7 +23,47 @@ TEST_CASE("CP 1") {
 
     Tensor<3, double> test1_cp = parafac_reconstruct<3, double>(factors);
 
-    double diff = rmsd(test1, test1_cp);
-
     REQUIRE((rmsd(test1, test1_cp) < 0.17392));
+}
+
+TEST_CASE("CP 2") {
+    using namespace einsums;
+    using namespace einsums::tensor_algebra;
+    using namespace einsums::decomposition;
+
+    Tensor<3, double> test2("test 2", 3, 4, 2);
+    
+    test2.vector_data() = std::vector<double, einsums::AlignedAllocator<double, 64>>
+                            {0.29945093, 0.0090937, 0.99788559, 0.0821231, 0.29625705, 0.80278977,
+                             0.15189681, 0.35832086, 0.09648153, 0.39398175, 0.49662056, 0.83101396,
+                             0.84288292, 0.48603425, 0.93286471, 0.47101289, 0.32736096, 0.50067919,
+                             0.49932342, 0.91922942, 0.44777189, 0.23009644, 0.34874549, 0.19356636};
+
+    auto factors = parafac(test2, 2, 10, 1.0e-6);
+
+    Tensor<3, double> test2_cp = parafac_reconstruct<3, double>(factors);
+
+    REQUIRE((rmsd(test2, test2_cp) <= 0.122492));
+}
+
+TEST_CASE("CP 3") {
+    using namespace einsums;
+    using namespace einsums::tensor_algebra;
+    using namespace einsums::decomposition;
+
+    Tensor<4, double> test3("test 3", 3, 2, 3, 2);
+    
+    test3.vector_data() = std::vector<double, einsums::AlignedAllocator<double, 64>>
+                            {0.37001224, 0.77676895, 0.17589323, 0.02762156, 0.21037116, 0.83686174,
+                             0.35042434, 0.19117270, 0.58095640, 0.99220655, 0.33536840, 0.15210615,
+                             0.95033534, 0.73212124, 0.31346639, 0.83961596, 0.15418801, 0.58927303,
+                             0.46744825, 0.44001279, 0.50372353, 0.09696069, 0.96449749, 0.71151666,
+                             0.72334792, 0.98646368, 0.13764230, 0.95949904, 0.07774470, 0.18239083,
+                             0.82591821, 0.40939436, 0.22088749, 0.90281597, 0.37465773, 0.02541923};
+
+    auto factors = parafac(test3, 2, 10, 1.0e-6);
+
+    Tensor<4, double> test2_cp = parafac_reconstruct<4, double>(factors);
+
+    REQUIRE((rmsd(test3, test2_cp) <= 0.228199));
 }

--- a/tests/Decomposition.cpp
+++ b/tests/Decomposition.cpp
@@ -19,13 +19,14 @@ TEST_CASE("CP 1") {
                              0.60919366, 0.97363788, 0.24531965, 0.23757898, 0.43426057, 0.64763913,
                              0.61224901, 0.86068415, 0.12051599};
 
-    auto factors = parafac(test1, 2, 20, 1.0e-6);
+    auto factors = parafac(test1, 2, 50, 1.0e-6);
 
     Tensor<3, double> test1_cp = parafac_reconstruct<3, double>(factors);
 
-    println(factors[0]);
-    
-    REQUIRE((rmsd(test1, test1_cp) < 0.17392));
+    double diff = rmsd(test1, test1_cp);
+
+    REQUIRE(isgreaterequal(diff, 0.0));
+    REQUIRE(islessequal(diff, 0.17392));
 }
 
 TEST_CASE("CP 2") {
@@ -41,13 +42,14 @@ TEST_CASE("CP 2") {
                              0.84288292, 0.48603425, 0.93286471, 0.47101289, 0.32736096, 0.50067919,
                              0.49932342, 0.91922942, 0.44777189, 0.23009644, 0.34874549, 0.19356636};
 
-    auto factors = parafac(test2, 2, 20, 1.0e-6);
+    auto factors = parafac(test2, 2, 50, 1.0e-6);
 
     Tensor<3, double> test2_cp = parafac_reconstruct<3, double>(factors);
 
-    println(factors[0]);
+    double diff = rmsd(test2, test2_cp);
 
-    REQUIRE((rmsd(test2, test2_cp) <= 0.122492));
+    REQUIRE(isgreaterequal(diff, 0.0));
+    REQUIRE(islessequal(diff, 0.122492));
 }
 
 TEST_CASE("CP 3") {
@@ -65,9 +67,12 @@ TEST_CASE("CP 3") {
                              0.72334792, 0.98646368, 0.13764230, 0.95949904, 0.07774470, 0.18239083,
                              0.82591821, 0.40939436, 0.22088749, 0.90281597, 0.37465773, 0.02541923};
 
-    auto factors = parafac(test3, 2, 20, 1.0e-6);
+    auto factors = parafac(test3, 2, 50, 1.0e-6);
 
-    Tensor<4, double> test2_cp = parafac_reconstruct<4, double>(factors);
+    Tensor<4, double> test3_cp = parafac_reconstruct<4, double>(factors);
 
-    REQUIRE((rmsd(test3, test2_cp) <= 0.228199));
+    double diff = rmsd(test3, test3_cp);
+
+    REQUIRE(isgreaterequal(diff, 0.0));
+    REQUIRE(islessequal(diff, 0.228199));
 }

--- a/tests/Decomposition.cpp
+++ b/tests/Decomposition.cpp
@@ -11,9 +11,22 @@ TEST_CASE("CP 1") {
     using namespace einsums::tensor_algebra;
     using namespace einsums::decomposition;
 
-    Tensor<3, double> I_rand = create_random_tensor("I_rand", 3, 4, 2);
+    Tensor<3, double> test1("test 1", 3, 3, 3);
+    test1.vector_data() = std::vector<double, einsums::AlignedAllocator<double, 64>>
+                            {0.94706517, 0.3959549, 0.14122476, 0.83665482, 0.27340639, 0.29811429,
+                             0.1823041, 0.66556282, 0.73178046, 0.72504222, 0.58360409, 0.68301135,
+                             0.8316929, 0.66955444, 0.25182224, 0.24108674, 0.09582611, 0.93056666,
+                             0.60919366, 0.97363788, 0.24531965, 0.23757898, 0.43426057, 0.64763913,
+                             0.61224901, 0.86068415, 0.12051599};
 
-    println(I_rand);
+    auto factors = parafac(test1, 2, 10, 1.0e-6);
 
-    auto factors = parafac(I_rand, 2, 10, 1.0e-6);
+    CHECK_THAT(factors[0].vector_data(), Catch::Matchers::Equals(std::vector<double, einsums::AlignedAllocator<double, 64>>{
+                                            1.52094859, 0.25583807, 1.74374003, 0.79559132, 1.498266, -0.50882886}));
+
+    CHECK_THAT(factors[1].vector_data(), Catch::Matchers::Equals(std::vector<double, einsums::AlignedAllocator<double, 64>>{
+                                            -0.66754524, -0.26756225, -0.5229646, 0.41945054, -0.54818362, -0.92958005}));
+    
+    CHECK_THAT(factors[2].vector_data(), Catch::Matchers::Equals(std::vector<double, einsums::AlignedAllocator<double, 64>>{
+                                            -0.66634092, 0.53102556, -0.62631181, 0.57979445, -0.44226493, -0.69426301}));
 }

--- a/tests/Decomposition.cpp
+++ b/tests/Decomposition.cpp
@@ -19,10 +19,12 @@ TEST_CASE("CP 1") {
                              0.60919366, 0.97363788, 0.24531965, 0.23757898, 0.43426057, 0.64763913,
                              0.61224901, 0.86068415, 0.12051599};
 
-    auto factors = parafac(test1, 2, 10, 1.0e-6);
+    auto factors = parafac(test1, 2, 20, 1.0e-6);
 
     Tensor<3, double> test1_cp = parafac_reconstruct<3, double>(factors);
 
+    println(factors[0]);
+    
     REQUIRE((rmsd(test1, test1_cp) < 0.17392));
 }
 
@@ -39,9 +41,11 @@ TEST_CASE("CP 2") {
                              0.84288292, 0.48603425, 0.93286471, 0.47101289, 0.32736096, 0.50067919,
                              0.49932342, 0.91922942, 0.44777189, 0.23009644, 0.34874549, 0.19356636};
 
-    auto factors = parafac(test2, 2, 10, 1.0e-6);
+    auto factors = parafac(test2, 2, 20, 1.0e-6);
 
     Tensor<3, double> test2_cp = parafac_reconstruct<3, double>(factors);
+
+    println(factors[0]);
 
     REQUIRE((rmsd(test2, test2_cp) <= 0.122492));
 }
@@ -61,7 +65,7 @@ TEST_CASE("CP 3") {
                              0.72334792, 0.98646368, 0.13764230, 0.95949904, 0.07774470, 0.18239083,
                              0.82591821, 0.40939436, 0.22088749, 0.90281597, 0.37465773, 0.02541923};
 
-    auto factors = parafac(test3, 2, 10, 1.0e-6);
+    auto factors = parafac(test3, 2, 20, 1.0e-6);
 
     Tensor<4, double> test2_cp = parafac_reconstruct<4, double>(factors);
 

--- a/tests/Decomposition.cpp
+++ b/tests/Decomposition.cpp
@@ -21,12 +21,9 @@ TEST_CASE("CP 1") {
 
     auto factors = parafac(test1, 2, 10, 1.0e-6);
 
-    CHECK_THAT(factors[0].vector_data(), Catch::Matchers::Equals(std::vector<double, einsums::AlignedAllocator<double, 64>>{
-                                            1.52094859, 0.25583807, 1.74374003, 0.79559132, 1.498266, -0.50882886}));
+    Tensor<3, double> test1_cp = parafac_reconstruct<3, double>(factors);
 
-    CHECK_THAT(factors[1].vector_data(), Catch::Matchers::Equals(std::vector<double, einsums::AlignedAllocator<double, 64>>{
-                                            -0.66754524, -0.26756225, -0.5229646, 0.41945054, -0.54818362, -0.92958005}));
-    
-    CHECK_THAT(factors[2].vector_data(), Catch::Matchers::Equals(std::vector<double, einsums::AlignedAllocator<double, 64>>{
-                                            -0.66634092, 0.53102556, -0.62631181, 0.57979445, -0.44226493, -0.69426301}));
+    double diff = rmsd(test1, test1_cp);
+
+    REQUIRE((rmsd(test1, test1_cp) < 0.17392));
 }


### PR DESCRIPTION
This code allows the decomposition of an arbitrary dimensional tensor into a sum of outer products of vectors (called candecomp, or CP, decomposition)

(i.e. `X[i][j][k] = \sum_{r} (a[i][r] * b[j][r] * c[k][r]`)