### PR TITLE
Expand BLAS/LAPACK interface

### DIFF
--- a/src/Blas.cpp
+++ b/src/Blas.cpp
@@ -32,6 +32,15 @@ void dgemm(char transa, char transb, int m, int n, int k, double alpha, const do
     ::einsums::backend::vendor::dgemm(transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc);
 }
 
+void cgemm(char transa, char transb, int m, int n, int k, std::complex<float> alpha, const std::complex<float> *a, int lda,
+           const std::complex<float> *b, int ldb, std::complex<float> beta, std::complex<float> *c, int ldc) {
+    ::einsums::backend::vendor::cgemm(transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc);
+}
+void zgemm(char transa, char transb, int m, int n, int k, std::complex<double> alpha, const std::complex<double> *a, int lda,
+           const std::complex<double> *b, int ldb, std::complex<double> beta, std::complex<double> *c, int ldc) {
+    ::einsums::backend::vendor::zgemm(transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc);
+}
+
 void dgemv(char transa, int m, int n, double alpha, const double *a, int lda, const double *x, int incx, double beta, double *y, int incy) {
     ::einsums::backend::vendor::dgemv(transa, m, n, alpha, a, lda, x, incx, beta, y, incy);
 }

--- a/src/Blas.cpp
+++ b/src/Blas.cpp
@@ -22,6 +22,11 @@ void finalize() {
 #endif
 }
 
+void sgemm(char transa, char transb, int m, int n, int k, float alpha, const float *a, int lda, const float *b, int ldb, float beta,
+           float *c, int ldc) {
+    ::einsums::backend::vendor::sgemm(transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc);
+}
+
 void dgemm(char transa, char transb, int m, int n, int k, double alpha, const double *a, int lda, const double *b, int ldb, double beta,
            double *c, int ldc) {
     ::einsums::backend::vendor::dgemm(transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc);

--- a/src/Blas.cpp
+++ b/src/Blas.cpp
@@ -67,8 +67,20 @@ auto dsyev(char job, char uplo, int n, double *a, int lda, double *w, double *wo
     return ::einsums::backend::vendor::dsyev(job, uplo, n, a, lda, w, work, lwork);
 }
 
+auto sgesv(int n, int nrhs, float *a, int lda, int *ipiv, float *b, int ldb) -> int {
+    return ::einsums::backend::vendor::sgesv(n, nrhs, a, lda, ipiv, b, ldb);
+}
+
 auto dgesv(int n, int nrhs, double *a, int lda, int *ipiv, double *b, int ldb) -> int {
     return ::einsums::backend::vendor::dgesv(n, nrhs, a, lda, ipiv, b, ldb);
+}
+
+auto cgesv(int n, int nrhs, std::complex<float> *a, int lda, int *ipiv, std::complex<float> *b, int ldb) -> int {
+    return ::einsums::backend::vendor::cgesv(n, nrhs, a, lda, ipiv, b, ldb);
+}
+
+auto zgesv(int n, int nrhs, std::complex<double> *a, int lda, int *ipiv, std::complex<double> *b, int ldb) -> int {
+    return ::einsums::backend::vendor::zgesv(n, nrhs, a, lda, ipiv, b, ldb);
 }
 
 auto cheev(char job, char uplo, int n, std::complex<float> *a, int lda, float *w, std::complex<float> *work, int lwork, float *rwork)

--- a/src/Blas.cpp
+++ b/src/Blas.cpp
@@ -41,8 +41,22 @@ void zgemm(char transa, char transb, int m, int n, int k, std::complex<double> a
     ::einsums::backend::vendor::zgemm(transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc);
 }
 
+void sgemv(char transa, int m, int n, float alpha, const float *a, int lda, const float *x, int incx, float beta, float *y, int incy) {
+    ::einsums::backend::vendor::sgemv(transa, m, n, alpha, a, lda, x, incx, beta, y, incy);
+}
+
 void dgemv(char transa, int m, int n, double alpha, const double *a, int lda, const double *x, int incx, double beta, double *y, int incy) {
     ::einsums::backend::vendor::dgemv(transa, m, n, alpha, a, lda, x, incx, beta, y, incy);
+}
+
+void cgemv(char transa, int m, int n, std::complex<float> alpha, const std::complex<float> *a, int lda, const std::complex<float> *x,
+           int incx, std::complex<float> beta, std::complex<float> *y, int incy) {
+    ::einsums::backend::vendor::cgemv(transa, m, n, alpha, a, lda, x, incx, beta, y, incy);
+}
+
+void zgemv(char transa, int m, int n, std::complex<double> alpha, const std::complex<double> *a, int lda, const std::complex<double> *x,
+           int incx, std::complex<double> beta, std::complex<double> *y, int incy) {
+    ::einsums::backend::vendor::zgemv(transa, m, n, alpha, a, lda, x, incx, beta, y, incy);
 }
 
 auto dsyev(char job, char uplo, int n, double *a, int lda, double *w, double *work, int lwork) -> int {

--- a/src/Blas.cpp
+++ b/src/Blas.cpp
@@ -59,12 +59,26 @@ void zgemv(char transa, int m, int n, std::complex<double> alpha, const std::com
     ::einsums::backend::vendor::zgemv(transa, m, n, alpha, a, lda, x, incx, beta, y, incy);
 }
 
+auto ssyev(char job, char uplo, int n, float *a, int lda, float *w, float *work, int lwork) -> int {
+    return ::einsums::backend::vendor::ssyev(job, uplo, n, a, lda, w, work, lwork);
+}
+
 auto dsyev(char job, char uplo, int n, double *a, int lda, double *w, double *work, int lwork) -> int {
     return ::einsums::backend::vendor::dsyev(job, uplo, n, a, lda, w, work, lwork);
 }
 
 auto dgesv(int n, int nrhs, double *a, int lda, int *ipiv, double *b, int ldb) -> int {
     return ::einsums::backend::vendor::dgesv(n, nrhs, a, lda, ipiv, b, ldb);
+}
+
+auto cheev(char job, char uplo, int n, std::complex<float> *a, int lda, float *w, std::complex<float> *work, int lwork, float *rwork)
+    -> int {
+    return ::einsums::backend::vendor::cheev(job, uplo, n, a, lda, w, work, lwork, rwork);
+}
+
+auto zheev(char job, char uplo, int n, std::complex<double> *a, int lda, double *w, std::complex<double> *work, int lwork, double *rwork)
+    -> int {
+    return ::einsums::backend::vendor::zheev(job, uplo, n, a, lda, w, work, lwork, rwork);
 }
 
 void dscal(int n, double alpha, double *vec, int inc) {

--- a/src/backends/vendor/Vendor.cpp
+++ b/src/backends/vendor/Vendor.cpp
@@ -42,6 +42,11 @@ extern void FC_GLOBAL(cgemv, CGEMV)(char *, int *, int *, std::complex<float> *,
 extern void FC_GLOBAL(zgemv, ZGEMV)(char *, int *, int *, std::complex<double> *, const std::complex<double> *, int *,
                                     const std::complex<double> *, int *, std::complex<double> *, std::complex<double> *, int *);
 
+extern void FC_GLOBAL(cheev, CHEEV)(char *job, char *uplo, int *n, std::complex<float> *a, int *lda, float *w, std::complex<float> *work,
+                                    int *lwork, float *rwork, int *info);
+extern void FC_GLOBAL(zheev, ZHEEV)(char *job, char *uplo, int *n, std::complex<double> *a, int *lda, double *w, std::complex<double> *work,
+                                    int *lwork, double *rwork, int *info);
+
 extern void FC_GLOBAL(ssyev, SSYEV)(char *, char *, int *, float *, int *, float *, float *, int *, int *);
 extern void FC_GLOBAL(dsyev, DSYEV)(char *, char *, int *, double *, int *, double *, double *, int *, int *);
 
@@ -150,6 +155,19 @@ auto ssyev(char job, char uplo, int n, float *a, int lda, float *w, float *work,
 auto dsyev(char job, char uplo, int n, double *a, int lda, double *w, double *work, int lwork) -> int {
     int info{0};
     FC_GLOBAL(dsyev, DSYEV)(&job, &uplo, &n, a, &lda, w, work, &lwork, &info);
+    return info;
+}
+
+auto cheev(char job, char uplo, int n, std::complex<float> *a, int lda, float *w, std::complex<float> *work, int lwork, float *rwork)
+    -> int {
+    int info{0};
+    FC_GLOBAL(cheev, CHEEV)(&job, &uplo, &n, a, &lda, w, work, &lwork, rwork, &info);
+    return info;
+}
+auto zheev(char job, char uplo, int n, std::complex<double> *a, int lda, double *w, std::complex<double> *work, int lwork, double *rwork)
+    -> int {
+    int info{0};
+    FC_GLOBAL(zheev, ZHEEV)(&job, &uplo, &n, a, &lda, w, work, &lwork, rwork, &info);
     return info;
 }
 

--- a/src/backends/vendor/Vendor.cpp
+++ b/src/backends/vendor/Vendor.cpp
@@ -24,6 +24,8 @@
 #endif
 
 extern "C" {
+extern void FC_GLOBAL(sgemm, SGEMM)(char *, char *, int *, int *, int *, float *, const float *, int *, const float *, int *, float *,
+                                    float *, int *);
 extern void FC_GLOBAL(dgemm, DGEMM)(char *, char *, int *, int *, int *, double *, const double *, int *, const double *, int *, double *,
                                     double *, int *);
 extern void FC_GLOBAL(dgemv, DGEMV)(char *, int *, int *, double *, const double *, int *, const double *, int *, double *, double *,
@@ -42,6 +44,13 @@ extern void FC_GLOBAL(dgesdd, DGESDD)(char *, int *, int *, double *, int *, dou
 }
 
 namespace einsums::backend::vendor {
+
+void sgemm(char transa, char transb, int m, int n, int k, float alpha, const float *a, int lda, const float *b, int ldb, float beta,
+           float *c, int ldc) {
+    if (m == 0 || n == 0 || k == 0)
+        return;
+    FC_GLOBAL(sgemm, SGEMM)(&transb, &transa, &n, &m, &k, &alpha, b, &ldb, a, &lda, &beta, c, &ldc);
+}
 
 void dgemm(char transa, char transb, int m, int n, int k, double alpha, const double *a, int lda, const double *b, int ldb, double beta,
            double *c, int ldc) {

--- a/src/backends/vendor/Vendor.cpp
+++ b/src/backends/vendor/Vendor.cpp
@@ -28,6 +28,10 @@ extern void FC_GLOBAL(sgemm, SGEMM)(char *, char *, int *, int *, int *, float *
                                     float *, int *);
 extern void FC_GLOBAL(dgemm, DGEMM)(char *, char *, int *, int *, int *, double *, const double *, int *, const double *, int *, double *,
                                     double *, int *);
+extern void FC_GLOBAL(cgemm, CGEMM)(char *, char *, int *, int *, int *, std::complex<float> *, const std::complex<float> *, int *,
+                                    const std::complex<float> *, int *, std::complex<float> *, std::complex<float> *, int *);
+extern void FC_GLOBAL(zgemm, ZGEMM)(char *, char *, int *, int *, int *, std::complex<double> *, const std::complex<double> *, int *,
+                                    const std::complex<double> *, int *, std::complex<double> *, std::complex<double> *, int *);
 extern void FC_GLOBAL(dgemv, DGEMV)(char *, int *, int *, double *, const double *, int *, const double *, int *, double *, double *,
                                     int *);
 extern void FC_GLOBAL(dsyev, DSYEV)(char *, char *, int *, double *, int *, double *, double *, int *, int *);
@@ -57,6 +61,20 @@ void dgemm(char transa, char transb, int m, int n, int k, double alpha, const do
     if (m == 0 || n == 0 || k == 0)
         return;
     FC_GLOBAL(dgemm, DGEMM)(&transb, &transa, &n, &m, &k, &alpha, b, &ldb, a, &lda, &beta, c, &ldc);
+}
+
+void cgemm(char transa, char transb, int m, int n, int k, std::complex<float> alpha, const std::complex<float> *a, int lda,
+           const std::complex<float> *b, int ldb, std::complex<float> beta, std::complex<float> *c, int ldc) {
+    if (m == 0 || n == 0 || k == 0)
+        return;
+    FC_GLOBAL(cgemm, CGEMM)(&transb, &transa, &n, &m, &k, &alpha, b, &ldb, a, &lda, &beta, c, &ldc);
+}
+
+void zgemm(char transa, char transb, int m, int n, int k, std::complex<double> alpha, const std::complex<double> *a, int lda,
+           const std::complex<double> *b, int ldb, std::complex<double> beta, std::complex<double> *c, int ldc) {
+    if (m == 0 || n == 0 || k == 0)
+        return;
+    FC_GLOBAL(zgemm, ZGEMM)(&transb, &transa, &n, &m, &k, &alpha, b, &ldb, a, &lda, &beta, c, &ldc);
 }
 
 void dgemv(char transa, int m, int n, double alpha, const double *a, int lda, const double *x, int incx, double beta, double *y, int incy) {

--- a/src/backends/vendor/Vendor.cpp
+++ b/src/backends/vendor/Vendor.cpp
@@ -24,6 +24,7 @@
 #endif
 
 extern "C" {
+
 extern void FC_GLOBAL(sgemm, SGEMM)(char *, char *, int *, int *, int *, float *, const float *, int *, const float *, int *, float *,
                                     float *, int *);
 extern void FC_GLOBAL(dgemm, DGEMM)(char *, char *, int *, int *, int *, double *, const double *, int *, const double *, int *, double *,
@@ -32,8 +33,15 @@ extern void FC_GLOBAL(cgemm, CGEMM)(char *, char *, int *, int *, int *, std::co
                                     const std::complex<float> *, int *, std::complex<float> *, std::complex<float> *, int *);
 extern void FC_GLOBAL(zgemm, ZGEMM)(char *, char *, int *, int *, int *, std::complex<double> *, const std::complex<double> *, int *,
                                     const std::complex<double> *, int *, std::complex<double> *, std::complex<double> *, int *);
+
+extern void FC_GLOBAL(sgemv, SGEMV)(char *, int *, int *, float *, const float *, int *, const float *, int *, float *, float *, int *);
 extern void FC_GLOBAL(dgemv, DGEMV)(char *, int *, int *, double *, const double *, int *, const double *, int *, double *, double *,
                                     int *);
+extern void FC_GLOBAL(cgemv, CGEMV)(char *, int *, int *, std::complex<float> *, const std::complex<float> *, int *,
+                                    const std::complex<float> *, int *, std::complex<float> *, std::complex<float> *, int *);
+extern void FC_GLOBAL(zgemv, ZGEMV)(char *, int *, int *, std::complex<double> *, const std::complex<double> *, int *,
+                                    const std::complex<double> *, int *, std::complex<double> *, std::complex<double> *, int *);
+
 extern void FC_GLOBAL(dsyev, DSYEV)(char *, char *, int *, double *, int *, double *, double *, int *, int *);
 extern void FC_GLOBAL(dgesv, DGESV)(int *, int *, double *, int *, int *, double *, int *, int *);
 extern void FC_GLOBAL(dscal, DSCAL)(int *, double *, double *, int *);
@@ -77,6 +85,19 @@ void zgemm(char transa, char transb, int m, int n, int k, std::complex<double> a
     FC_GLOBAL(zgemm, ZGEMM)(&transb, &transa, &n, &m, &k, &alpha, b, &ldb, a, &lda, &beta, c, &ldc);
 }
 
+void sgemv(char transa, int m, int n, float alpha, const float *a, int lda, const float *x, int incx, float beta, float *y, int incy) {
+    if (m == 0 || n == 0)
+        return;
+    if (transa == 'N' || transa == 'n')
+        transa = 'T';
+    else if (transa == 'T' || transa == 't')
+        transa = 'N';
+    else
+        throw std::invalid_argument("einsums::backend::vendor::dgemv transa argument is invalid.");
+
+    FC_GLOBAL(sgemv, SGEMV)(&transa, &n, &m, &alpha, a, &lda, x, &incx, &beta, y, &incy);
+}
+
 void dgemv(char transa, int m, int n, double alpha, const double *a, int lda, const double *x, int incx, double beta, double *y, int incy) {
     if (m == 0 || n == 0)
         return;
@@ -88,6 +109,34 @@ void dgemv(char transa, int m, int n, double alpha, const double *a, int lda, co
         throw std::invalid_argument("einsums::backend::vendor::dgemv transa argument is invalid.");
 
     FC_GLOBAL(dgemv, DGEMV)(&transa, &n, &m, &alpha, a, &lda, x, &incx, &beta, y, &incy);
+}
+
+void cgemv(char transa, int m, int n, std::complex<float> alpha, const std::complex<float> *a, int lda, const std::complex<float> *x,
+           int incx, std::complex<float> beta, std::complex<float> *y, int incy) {
+    if (m == 0 || n == 0)
+        return;
+    if (transa == 'N' || transa == 'n')
+        transa = 'T';
+    else if (transa == 'T' || transa == 't')
+        transa = 'N';
+    else
+        throw std::invalid_argument("einsums::backend::vendor::dgemv transa argument is invalid.");
+
+    FC_GLOBAL(cgemv, CGEMV)(&transa, &n, &m, &alpha, a, &lda, x, &incx, &beta, y, &incy);
+}
+
+void zgemv(char transa, int m, int n, std::complex<double> alpha, const std::complex<double> *a, int lda, const std::complex<double> *x,
+           int incx, std::complex<double> beta, std::complex<double> *y, int incy) {
+    if (m == 0 || n == 0)
+        return;
+    if (transa == 'N' || transa == 'n')
+        transa = 'T';
+    else if (transa == 'T' || transa == 't')
+        transa = 'N';
+    else
+        throw std::invalid_argument("einsums::backend::vendor::dgemv transa argument is invalid.");
+
+    FC_GLOBAL(zgemv, ZGEMV)(&transa, &n, &m, &alpha, a, &lda, x, &incx, &beta, y, &incy);
 }
 
 auto dsyev(char job, char uplo, int n, double *a, int lda, double *w, double *work, int lwork) -> int {

--- a/src/backends/vendor/Vendor.cpp
+++ b/src/backends/vendor/Vendor.cpp
@@ -50,7 +50,11 @@ extern void FC_GLOBAL(zheev, ZHEEV)(char *job, char *uplo, int *n, std::complex<
 extern void FC_GLOBAL(ssyev, SSYEV)(char *, char *, int *, float *, int *, float *, float *, int *, int *);
 extern void FC_GLOBAL(dsyev, DSYEV)(char *, char *, int *, double *, int *, double *, double *, int *, int *);
 
+extern void FC_GLOBAL(sgesv, SGESV)(int *, int *, float *, int *, int *, float *, int *, int *);
 extern void FC_GLOBAL(dgesv, DGESV)(int *, int *, double *, int *, int *, double *, int *, int *);
+extern void FC_GLOBAL(cgesv, CGESV)(int *, int *, std::complex<float> *, int *, int *, std::complex<float> *, int *, int *);
+extern void FC_GLOBAL(zgesv, ZGESV)(int *, int *, std::complex<double> *, int *, int *, std::complex<double> *, int *, int *);
+
 extern void FC_GLOBAL(dscal, DSCAL)(int *, double *, double *, int *);
 extern double FC_GLOBAL(ddot, DDOT)(int *, const double *, int *, const double *, int *); // NOLINT
 extern void FC_GLOBAL(daxpy, DAXPY)(int *, double *, const double *, int *, double *, int *);
@@ -171,9 +175,27 @@ auto zheev(char job, char uplo, int n, std::complex<double> *a, int lda, double 
     return info;
 }
 
+auto sgesv(int n, int nrhs, float *a, int lda, int *ipiv, float *b, int ldb) -> int {
+    int info{0};
+    FC_GLOBAL(sgesv, SGESV)(&n, &nrhs, a, &lda, ipiv, b, &ldb, &info);
+    return info;
+}
+
 auto dgesv(int n, int nrhs, double *a, int lda, int *ipiv, double *b, int ldb) -> int {
     int info{0};
     FC_GLOBAL(dgesv, DGESV)(&n, &nrhs, a, &lda, ipiv, b, &ldb, &info);
+    return info;
+}
+
+auto cgesv(int n, int nrhs, std::complex<float> *a, int lda, int *ipiv, std::complex<float> *b, int ldb) -> int {
+    int info{0};
+    FC_GLOBAL(cgesv, CGESV)(&n, &nrhs, a, &lda, ipiv, b, &ldb, &info);
+    return info;
+}
+
+auto zgesv(int n, int nrhs, std::complex<double> *a, int lda, int *ipiv, std::complex<double> *b, int ldb) -> int {
+    int info{0};
+    FC_GLOBAL(zgesv, ZGESV)(&n, &nrhs, a, &lda, ipiv, b, &ldb, &info);
     return info;
 }
 

--- a/src/backends/vendor/Vendor.cpp
+++ b/src/backends/vendor/Vendor.cpp
@@ -42,7 +42,9 @@ extern void FC_GLOBAL(cgemv, CGEMV)(char *, int *, int *, std::complex<float> *,
 extern void FC_GLOBAL(zgemv, ZGEMV)(char *, int *, int *, std::complex<double> *, const std::complex<double> *, int *,
                                     const std::complex<double> *, int *, std::complex<double> *, std::complex<double> *, int *);
 
+extern void FC_GLOBAL(ssyev, SSYEV)(char *, char *, int *, float *, int *, float *, float *, int *, int *);
 extern void FC_GLOBAL(dsyev, DSYEV)(char *, char *, int *, double *, int *, double *, double *, int *, int *);
+
 extern void FC_GLOBAL(dgesv, DGESV)(int *, int *, double *, int *, int *, double *, int *, int *);
 extern void FC_GLOBAL(dscal, DSCAL)(int *, double *, double *, int *);
 extern double FC_GLOBAL(ddot, DDOT)(int *, const double *, int *, const double *, int *); // NOLINT
@@ -137,6 +139,12 @@ void zgemv(char transa, int m, int n, std::complex<double> alpha, const std::com
         throw std::invalid_argument("einsums::backend::vendor::dgemv transa argument is invalid.");
 
     FC_GLOBAL(zgemv, ZGEMV)(&transa, &n, &m, &alpha, a, &lda, x, &incx, &beta, y, &incy);
+}
+
+auto ssyev(char job, char uplo, int n, float *a, int lda, float *w, float *work, int lwork) -> int {
+    int info{0};
+    FC_GLOBAL(ssyev, SSYEV)(&job, &uplo, &n, a, &lda, w, work, &lwork, &info);
+    return info;
 }
 
 auto dsyev(char job, char uplo, int n, double *a, int lda, double *w, double *work, int lwork) -> int {

--- a/src/backends/vendor/Vendor.hpp
+++ b/src/backends/vendor/Vendor.hpp
@@ -29,6 +29,7 @@ void zgemv(char transa, int m, int n, std::complex<double> alpha, const std::com
 /*!
  * Performs symmetric matrix diagonalization.
  */
+auto ssyev(char job, char uplo, int n, float *a, int lda, float *w, float *work, int lwork) -> int;
 auto dsyev(char job, char uplo, int n, double *a, int lda, double *w, double *work, int lwork) -> int;
 
 /*!

--- a/src/backends/vendor/Vendor.hpp
+++ b/src/backends/vendor/Vendor.hpp
@@ -44,7 +44,10 @@ auto zheev(char job, char uplo, int n, std::complex<double> *a, int lda, double 
  * Computes the solution to system of linear equations A * x = B for general
  * matrices.
  */
+auto sgesv(int n, int nrhs, float *a, int lda, int *ipiv, float *b, int ldb) -> int;
 auto dgesv(int n, int nrhs, double *a, int lda, int *ipiv, double *b, int ldb) -> int;
+auto cgesv(int n, int nrhs, std::complex<float> *a, int lda, int *ipiv, std::complex<float> *b, int ldb) -> int;
+auto zgesv(int n, int nrhs, std::complex<double> *a, int lda, int *ipiv, std::complex<double> *b, int ldb) -> int;
 
 void dscal(int n, double alpha, double *vec, int inc);
 

--- a/src/backends/vendor/Vendor.hpp
+++ b/src/backends/vendor/Vendor.hpp
@@ -5,6 +5,8 @@ namespace einsums::backend::vendor {
 /*!
  * Performs matrix multiplication for general square matices of type double.
  */
+void sgemm(char transa, char transb, int m, int n, int k, float alpha, const float *a, int lda, const float *b, int ldb, float beta,
+           float *c, int ldc);
 void dgemm(char transa, char transb, int m, int n, int k, double alpha, const double *a, int lda, const double *b, int ldb, double beta,
            double *c, int ldc);
 

--- a/src/backends/vendor/Vendor.hpp
+++ b/src/backends/vendor/Vendor.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <complex>
+
 namespace einsums::backend::vendor {
 
 /*!
@@ -9,6 +11,10 @@ void sgemm(char transa, char transb, int m, int n, int k, float alpha, const flo
            float *c, int ldc);
 void dgemm(char transa, char transb, int m, int n, int k, double alpha, const double *a, int lda, const double *b, int ldb, double beta,
            double *c, int ldc);
+void cgemm(char transa, char transb, int m, int n, int k, std::complex<float> alpha, const std::complex<float> *a, int lda,
+           const std::complex<float> *b, int ldb, std::complex<float> beta, std::complex<float> *c, int ldc);
+void zgemm(char transa, char transb, int m, int n, int k, std::complex<double> alpha, const std::complex<double> *a, int lda,
+           const std::complex<double> *b, int ldb, std::complex<double> beta, std::complex<double> *c, int ldc);
 
 /*!
  * Performs matrix vector multiplication.

--- a/src/backends/vendor/Vendor.hpp
+++ b/src/backends/vendor/Vendor.hpp
@@ -33,6 +33,14 @@ auto ssyev(char job, char uplo, int n, float *a, int lda, float *w, float *work,
 auto dsyev(char job, char uplo, int n, double *a, int lda, double *w, double *work, int lwork) -> int;
 
 /*!
+ * Computes all eigenvalues and, optionally, eigenvectors of a Hermitian matrix.
+ */
+auto cheev(char job, char uplo, int n, std::complex<float> *a, int lda, float *w, std::complex<float> *work, int lwork, float *rwork)
+    -> int;
+auto zheev(char job, char uplo, int n, std::complex<double> *a, int lda, double *w, std::complex<double> *work, int lwork, double *rwork)
+    -> int;
+
+/*!
  * Computes the solution to system of linear equations A * x = B for general
  * matrices.
  */

--- a/src/backends/vendor/Vendor.hpp
+++ b/src/backends/vendor/Vendor.hpp
@@ -19,7 +19,12 @@ void zgemm(char transa, char transb, int m, int n, int k, std::complex<double> a
 /*!
  * Performs matrix vector multiplication.
  */
+void sgemv(char transa, int m, int n, float alpha, const float *a, int lda, const float *x, int incx, float beta, float *y, int incy);
 void dgemv(char transa, int m, int n, double alpha, const double *a, int lda, const double *x, int incx, double beta, double *y, int incy);
+void cgemv(char transa, int m, int n, std::complex<float> alpha, const std::complex<float> *a, int lda, const std::complex<float> *x,
+           int incx, std::complex<float> beta, std::complex<float> *y, int incy);
+void zgemv(char transa, int m, int n, std::complex<double> alpha, const std::complex<double> *a, int lda, const std::complex<double> *x,
+           int incx, std::complex<double> beta, std::complex<double> *y, int incy);
 
 /*!
  * Performs symmetric matrix diagonalization.

--- a/src/include/einsums/Blas.hpp
+++ b/src/include/einsums/Blas.hpp
@@ -92,7 +92,21 @@ inline void gemv<std::complex<double>>(char transa, int m, int n, std::complex<d
 /*!
  * Performs symmetric matrix diagonalization.
  */
+auto ssyev(char job, char uplo, int n, float *a, int lda, float *w, float *work, int lwork) -> int;
 auto dsyev(char job, char uplo, int n, double *a, int lda, double *w, double *work, int lwork) -> int;
+
+template <typename T>
+auto syev(char job, char uplo, int n, T *a, int lda, T *w, T *work, int lwork) -> int;
+
+template <>
+inline auto syev<double>(char job, char uplo, int n, double *a, int lda, double *w, double *work, int lwork) -> int {
+    return dsyev(job, uplo, n, a, lda, w, work, lwork);
+}
+
+template <>
+inline auto syev<float>(char job, char uplo, int n, float *a, int lda, float *w, float *work, int lwork) -> int {
+    return ssyev(job, uplo, n, a, lda, w, work, lwork);
+}
 
 /*!
  * Computes the solution to system of linear equations A * x = B for general

--- a/src/include/einsums/Blas.hpp
+++ b/src/include/einsums/Blas.hpp
@@ -54,7 +54,40 @@ inline void gemm<std::complex<double>>(char transa, char transb, int m, int n, i
 /*!
  * Performs matrix vector multiplication.
  */
+void sgemv(char transa, int m, int n, float alpha, const float *a, int lda, const float *x, int incx, float beta, float *y, int incy);
 void dgemv(char transa, int m, int n, double alpha, const double *a, int lda, const double *x, int incx, double beta, double *y, int incy);
+void cgemv(char transa, int m, int n, std::complex<float> alpha, const std::complex<float> *a, int lda, const std::complex<float> *x,
+           int incx, std::complex<float> beta, std::complex<float> *y, int incy);
+void zgemv(char transa, int m, int n, std::complex<double> alpha, const std::complex<double> *a, int lda, const std::complex<double> *x,
+           int incx, std::complex<double> beta, std::complex<double> *y, int incy);
+
+template <typename T>
+void gemv(char transa, int m, int n, T alpha, const T *a, int lda, const T *x, int incx, T beta, T *y, int incy);
+
+template <>
+inline void gemv<float>(char transa, int m, int n, float alpha, const float *a, int lda, const float *x, int incx, float beta, float *y,
+                        int incy) {
+    sgemv(transa, m, n, alpha, a, lda, x, incx, beta, y, incy);
+}
+
+template <>
+inline void gemv<double>(char transa, int m, int n, double alpha, const double *a, int lda, const double *x, int incx, double beta,
+                         double *y, int incy) {
+    dgemv(transa, m, n, alpha, a, lda, x, incx, beta, y, incy);
+}
+
+template <>
+inline void gemv<std::complex<float>>(char transa, int m, int n, std::complex<float> alpha, const std::complex<float> *a, int lda,
+                                      const std::complex<float> *x, int incx, std::complex<float> beta, std::complex<float> *y, int incy) {
+    cgemv(transa, m, n, alpha, a, lda, x, incx, beta, y, incy);
+}
+
+template <>
+inline void gemv<std::complex<double>>(char transa, int m, int n, std::complex<double> alpha, const std::complex<double> *a, int lda,
+                                       const std::complex<double> *x, int incx, std::complex<double> beta, std::complex<double> *y,
+                                       int incy) {
+    zgemv(transa, m, n, alpha, a, lda, x, incx, beta, y, incy);
+}
 
 /*!
  * Performs symmetric matrix diagonalization.

--- a/src/include/einsums/Blas.hpp
+++ b/src/include/einsums/Blas.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <complex>
 #include <vector>
 
 // Namespace for BLAS and LAPACK routines.
@@ -12,8 +13,43 @@ void finalize();
 /*!
  * Performs matrix multiplication for general square matices of type double.
  */
+void sgemm(char transa, char transb, int m, int n, int k, float alpha, const float *a, int lda, const float *b, int ldb, float beta,
+           float *c, int ldc);
 void dgemm(char transa, char transb, int m, int n, int k, double alpha, const double *a, int lda, const double *b, int ldb, double beta,
            double *c, int ldc);
+void cgemm(char transa, char transb, int m, int n, int k, std::complex<float> alpha, const std::complex<float> *a, int lda,
+           const std::complex<float> *b, int ldb, std::complex<float> beta, std::complex<float> *c, int ldc);
+void zgemm(char transa, char transb, int m, int n, int k, std::complex<double> alpha, const std::complex<double> *a, int lda,
+           const std::complex<double> *b, int ldb, std::complex<double> beta, std::complex<double> *c, int ldc);
+
+template <typename T>
+void gemm(char transa, char transb, int m, int n, int k, T alpha, const T *a, int lda, const T *b, int ldb, T beta, T *c, int ldc);
+
+template <>
+inline void gemm<float>(char transa, char transb, int m, int n, int k, float alpha, const float *a, int lda, const float *b, int ldb,
+                        float beta, float *c, int ldc) {
+    sgemm(transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc);
+}
+
+template <>
+inline void gemm<double>(char transa, char transb, int m, int n, int k, double alpha, const double *a, int lda, const double *b, int ldb,
+                         double beta, double *c, int ldc) {
+    dgemm(transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc);
+}
+
+template <>
+inline void gemm<std::complex<float>>(char transa, char transb, int m, int n, int k, std::complex<float> alpha,
+                                      const std::complex<float> *a, int lda, const std::complex<float> *b, int ldb,
+                                      std::complex<float> beta, std::complex<float> *c, int ldc) {
+    cgemm(transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc);
+}
+
+template <>
+inline void gemm<std::complex<double>>(char transa, char transb, int m, int n, int k, std::complex<double> alpha,
+                                       const std::complex<double> *a, int lda, const std::complex<double> *b, int ldb,
+                                       std::complex<double> beta, std::complex<double> *c, int ldc) {
+    zgemm(transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc);
+}
 
 /*!
  * Performs matrix vector multiplication.

--- a/src/include/einsums/Blas.hpp
+++ b/src/include/einsums/Blas.hpp
@@ -134,7 +134,34 @@ inline auto heev<double>(char job, char uplo, int n, std::complex<double> *a, in
  * Computes the solution to system of linear equations A * x = B for general
  * matrices.
  */
+auto sgesv(int n, int nrhs, float *a, int lda, int *ipiv, float *b, int ldb) -> int;
 auto dgesv(int n, int nrhs, double *a, int lda, int *ipiv, double *b, int ldb) -> int;
+auto cgesv(int n, int nrhs, std::complex<float> *a, int lda, int *ipiv, std::complex<float> *b, int ldb) -> int;
+auto zgesv(int n, int nrhs, std::complex<double> *a, int lda, int *ipiv, std::complex<double> *b, int ldb) -> int;
+
+template <typename T>
+auto gesv(int n, int nrhs, T *a, int lda, int *ipiv, T *b, int ldb) -> int;
+
+template <>
+inline auto gesv<float>(int n, int nrhs, float *a, int lda, int *ipiv, float *b, int ldb) -> int {
+    return sgesv(n, nrhs, a, lda, ipiv, b, ldb);
+}
+
+template <>
+inline auto gesv<double>(int n, int nrhs, double *a, int lda, int *ipiv, double *b, int ldb) -> int {
+    return dgesv(n, nrhs, a, lda, ipiv, b, ldb);
+}
+
+template <>
+inline auto gesv<std::complex<float>>(int n, int nrhs, std::complex<float> *a, int lda, int *ipiv, std::complex<float> *b, int ldb) -> int {
+    return cgesv(n, nrhs, a, lda, ipiv, b, ldb);
+}
+
+template <>
+inline auto gesv<std::complex<double>>(int n, int nrhs, std::complex<double> *a, int lda, int *ipiv, std::complex<double> *b, int ldb)
+    -> int {
+    return zgesv(n, nrhs, a, lda, ipiv, b, ldb);
+}
 
 void dscal(int n, double alpha, double *vec, int inc);
 

--- a/src/include/einsums/Blas.hpp
+++ b/src/include/einsums/Blas.hpp
@@ -99,13 +99,35 @@ template <typename T>
 auto syev(char job, char uplo, int n, T *a, int lda, T *w, T *work, int lwork) -> int;
 
 template <>
+inline auto syev<float>(char job, char uplo, int n, float *a, int lda, float *w, float *work, int lwork) -> int {
+    return ssyev(job, uplo, n, a, lda, w, work, lwork);
+}
+template <>
 inline auto syev<double>(char job, char uplo, int n, double *a, int lda, double *w, double *work, int lwork) -> int {
     return dsyev(job, uplo, n, a, lda, w, work, lwork);
 }
 
+/*!
+ * Computes all eigenvalues and, optionally, eigenvectors of a Hermitian matrix.
+ */
+auto cheev(char job, char uplo, int n, std::complex<float> *a, int lda, float *w, std::complex<float> *work, int lwork, float *rwork)
+    -> int;
+auto zheev(char job, char uplo, int n, std::complex<double> *a, int lda, double *w, std::complex<double> *work, int lwork, double *rworl)
+    -> int;
+
+template <typename T>
+auto heev(char job, char uplo, int n, std::complex<T> *a, int lda, T *w, std::complex<T> *work, int lwork, T *rwork) -> int;
+
 template <>
-inline auto syev<float>(char job, char uplo, int n, float *a, int lda, float *w, float *work, int lwork) -> int {
-    return ssyev(job, uplo, n, a, lda, w, work, lwork);
+inline auto heev<float>(char job, char uplo, int n, std::complex<float> *a, int lda, float *w, std::complex<float> *work, int lwork,
+                        float *rwork) -> int {
+    return cheev(job, uplo, n, a, lda, w, work, lwork, rwork);
+}
+
+template <>
+inline auto heev<double>(char job, char uplo, int n, std::complex<double> *a, int lda, double *w, std::complex<double> *work, int lwork,
+                         double *rwork) -> int {
+    return zheev(job, uplo, n, a, lda, w, work, lwork, rwork);
 }
 
 /*!

--- a/src/include/einsums/Decomposition.hpp
+++ b/src/include/einsums/Decomposition.hpp
@@ -102,7 +102,7 @@ auto initialize_cp(std::vector<Tensor<TType, 2>> &folds, size_t rank) -> std::ve
         }
 
         // Need to save the factors
-        factors.emplace_back(Tensor{U(All{}, Range{0, rank})});
+        factors.emplace_back(Tensor{U(All, Range{0, rank})});
     });
 
     return factors;
@@ -291,7 +291,7 @@ auto initialize_tucker(std::vector<Tensor<TType, 2>> &folds, std::vector<size_t>
         }
 
         // Need to save the factors
-        factors.emplace_back(Tensor{U(All{}, Range{0, rank})});
+        factors.emplace_back(Tensor{U(All, Range{0, rank})});
     });
 
     return factors;

--- a/src/include/einsums/H5.hpp
+++ b/src/include/einsums/H5.hpp
@@ -8,44 +8,44 @@ namespace h5::impl {
 // 1. Object -> H5T_xxx
 //    Conversion from Tensor to the underlying double.
 template <typename T, size_t Rank>
-struct decay<::einsums::Tensor<Rank, T>> {
+struct decay<::einsums::Tensor<T, Rank>> {
     using type = T;
 };
 
 template <typename T, size_t Rank>
-struct decay<::einsums::TensorView<Rank, T>> {
+struct decay<::einsums::TensorView<T, Rank>> {
     using type = T;
 };
 
 template <typename T, size_t Rank>
-auto data(const ::einsums::Tensor<Rank, T> &ref) -> const T * {
+auto data(const ::einsums::Tensor<T, Rank> &ref) -> const T * {
     return ref.data();
 }
 
 template <typename T, size_t Rank>
-auto data(const ::einsums::TensorView<Rank, T> &ref) -> const T * {
+auto data(const ::einsums::TensorView<T, Rank> &ref) -> const T * {
     return ref.data();
 }
 
 template <typename T, size_t Rank>
-auto data(::einsums::Tensor<Rank, T> &ref) -> T * {
+auto data(::einsums::Tensor<T, Rank> &ref) -> T * {
     return ref.data();
 }
 
 // Determine rank and dimensions
 template <typename T, size_t Rank>
-struct rank<::einsums::Tensor<Rank, T>> : public std::integral_constant<size_t, Rank> {};
+struct rank<::einsums::Tensor<T, Rank>> : public std::integral_constant<size_t, Rank> {};
 
 template <typename T, size_t Rank>
-struct rank<::einsums::TensorView<Rank, T>> : public std::integral_constant<size_t, Rank> {};
+struct rank<::einsums::TensorView<T, Rank>> : public std::integral_constant<size_t, Rank> {};
 
 template <typename T, size_t Rank>
-inline auto size(const ::einsums::Tensor<Rank, T> &ref) -> std::array<size_t, Rank> {
+inline auto size(const ::einsums::Tensor<T, Rank> &ref) -> std::array<size_t, Rank> {
     return ref.dims();
 }
 
 template <typename T, size_t Rank>
-inline auto size(const ::einsums::TensorView<Rank, T> &ref) -> std::array<size_t, Rank> {
+inline auto size(const ::einsums::TensorView<T, Rank> &ref) -> std::array<size_t, Rank> {
     return ref.dims();
 }
 
@@ -53,27 +53,27 @@ inline auto size(const ::einsums::TensorView<Rank, T> &ref) -> std::array<size_t
 //  Not sure if this can be generalized.
 //  Only allow Tensor to be read in and not TensorView
 template <typename T>
-struct get<::einsums::Tensor<1, T>> {
-    static inline auto ctor(std::array<size_t, 1> dims) -> ::einsums::Tensor<1, T> {
-        return ::einsums::Tensor<1, T>("hdf5 auto created", dims[0]);
+struct get<::einsums::Tensor<T, 1>> {
+    static inline auto ctor(std::array<size_t, 1> dims) -> ::einsums::Tensor<T, 1> {
+        return ::einsums::Tensor<T, 1>("hdf5 auto created", dims[0]);
     }
 };
 template <typename T>
-struct get<::einsums::Tensor<2, T>> {
-    static inline auto ctor(std::array<size_t, 2> dims) -> ::einsums::Tensor<2, T> {
-        return ::einsums::Tensor<2, T>("hdf5 auto created", dims[0], dims[1]);
+struct get<::einsums::Tensor<T, 2>> {
+    static inline auto ctor(std::array<size_t, 2> dims) -> ::einsums::Tensor<T, 2> {
+        return ::einsums::Tensor<T, 2>("hdf5 auto created", dims[0], dims[1]);
     }
 };
 template <typename T>
-struct get<::einsums::Tensor<3, T>> {
-    static inline auto ctor(std::array<size_t, 3> dims) -> ::einsums::Tensor<3, T> {
-        return ::einsums::Tensor<3, T>("hdf5 auto created", dims[0], dims[1], dims[2]);
+struct get<::einsums::Tensor<T, 3>> {
+    static inline auto ctor(std::array<size_t, 3> dims) -> ::einsums::Tensor<T, 3> {
+        return ::einsums::Tensor<T, 3>("hdf5 auto created", dims[0], dims[1], dims[2]);
     }
 };
 template <typename T>
-struct get<::einsums::Tensor<4, T>> {
-    static inline auto ctor(std::array<size_t, 4> dims) -> ::einsums::Tensor<4, T> {
-        return ::einsums::Tensor<4, T>("hdf5 auto created", dims[0], dims[1], dims[2], dims[3]);
+struct get<::einsums::Tensor<T, 4>> {
+    static inline auto ctor(std::array<size_t, 4> dims) -> ::einsums::Tensor<T, 4> {
+        return ::einsums::Tensor<T, 4>("hdf5 auto created", dims[0], dims[1], dims[2], dims[3]);
     }
 };
 
@@ -83,6 +83,8 @@ struct get<::einsums::Tensor<4, T>> {
 
 namespace h5 {
 
-inline bool exists(hid_t hid, const std::string &name) { return H5Lexists(hid, name.c_str(), H5P_DEFAULT) > 0 ? true : false; }
+inline bool exists(hid_t hid, const std::string &name) {
+    return H5Lexists(hid, name.c_str(), H5P_DEFAULT) > 0 ? true : false;
+}
 
 } // namespace h5

--- a/src/include/einsums/LinearAlgebra.hpp
+++ b/src/include/einsums/LinearAlgebra.hpp
@@ -116,7 +116,7 @@ auto syev(const AType<T, ARank> &A) ->
     Tensor<T, 2> a = A;
     Tensor<T, 1> w{"eigenvalues", A.dim(0)};
 
-    syev<ComputeEigenvectors>(&a, &w);
+    blas::syev<ComputeEigenvectors>(&a, &w);
 
     return std::make_tuple(a, w);
 }

--- a/src/include/einsums/LinearAlgebra.hpp
+++ b/src/include/einsums/LinearAlgebra.hpp
@@ -19,14 +19,14 @@ namespace einsums::linear_algebra {
 
 template <bool TransA, bool TransB, template <size_t, typename> typename AType, template <size_t, typename> typename BType,
           template <size_t, typename> typename CType, size_t Rank, typename T>
-auto gemm(const double alpha, const AType<Rank, T> &A, const BType<Rank, T> &B, const double beta, CType<Rank, T> *C) ->
+auto gemm(const T alpha, const AType<Rank, T> &A, const BType<Rank, T> &B, const T beta, CType<Rank, T> *C) ->
     typename std::enable_if_t<is_incore_rank_tensor_v<AType<Rank, T>, 2, T> && is_incore_rank_tensor_v<BType<Rank, T>, 2, T> &&
                               is_incore_rank_tensor_v<CType<Rank, T>, 2, T>> {
     auto m = C->dim(0), n = C->dim(1), k = TransA ? A.dim(0) : A.dim(1);
     auto lda = A.stride(0), ldb = B.stride(0), ldc = C->stride(0);
 
     timer::push(fmt::format("gemm<{}, {}>", TransA, TransB));
-    blas::dgemm(TransA ? 't' : 'n', TransB ? 't' : 'n', m, n, k, alpha, A.data(), lda, B.data(), ldb, beta, C->data(), ldc);
+    blas::gemm(TransA ? 't' : 'n', TransB ? 't' : 'n', m, n, k, alpha, A.data(), lda, B.data(), ldb, beta, C->data(), ldc);
     timer::pop();
 }
 
@@ -49,7 +49,7 @@ auto gemm(const double alpha, const AType<Rank, T> &A, const BType<Rank, T> &B, 
  */
 template <bool TransA, bool TransB, template <size_t, typename> typename AType, template <size_t, typename> typename BType, size_t Rank,
           typename T>
-auto gemm(const double alpha, const AType<Rank, T> &A, const BType<Rank, T> &B)
+auto gemm(const T alpha, const AType<Rank, T> &A, const BType<Rank, T> &B)
     -> std::enable_if_t<is_incore_rank_tensor_v<AType<Rank, T>, 2, T> && is_incore_rank_tensor_v<BType<Rank, T>, 2, T>, Tensor<2, double>> {
     Tensor<2, double> C{"gemm result", TransA ? A.dim(1) : A.dim(0), TransB ? B.dim(1) : B.dim(0)};
 

--- a/src/include/einsums/LinearAlgebra.hpp
+++ b/src/include/einsums/LinearAlgebra.hpp
@@ -69,7 +69,7 @@ auto gemv(const double alpha, const AType<T, ARank> &A, const XType<T, XYRank> &
     auto incy = y->stride(0);
 
     timer::push(fmt::format("gemv<{}>", TransA));
-    blas::dgemv(TransA ? 't' : 'n', m, n, alpha, A.data(), lda, x.data(), incx, beta, y->data(), incy);
+    blas::gemv(TransA ? 't' : 'n', m, n, alpha, A.data(), lda, x.data(), incx, beta, y->data(), incy);
     timer::pop();
 }
 
@@ -82,10 +82,10 @@ auto syev(AType<T, ARank> *A, WType<T, WRank> *W)
     auto n = A->dim(0);
     auto lda = A->stride(0);
     int lwork = 3 * n;
-    std::vector<double> work(lwork);
+    std::vector<T> work(lwork);
 
     timer::push(fmt::format("syev<ComputeEigenvectors={}>", ComputeEigenvectors));
-    blas::dsyev(ComputeEigenvectors ? 'v' : 'n', 'u', n, A->data(), lda, W->data(), work.data(), lwork);
+    blas::syev(ComputeEigenvectors ? 'v' : 'n', 'u', n, A->data(), lda, W->data(), work.data(), lwork);
     timer::pop();
 }
 

--- a/src/include/einsums/LinearAlgebra.hpp
+++ b/src/include/einsums/LinearAlgebra.hpp
@@ -110,6 +110,7 @@ auto heev(AType<T, ARank> *A, WType<typename complex_type<T>::type, WRank> *W)
 template <template <typename, size_t> typename AType, size_t ARank, template <typename, size_t> typename BType, size_t BRank, typename T>
 auto gesv(AType<T, ARank> *A, BType<T, BRank> *B)
     -> std::enable_if_t<is_incore_rank_tensor_v<AType<T, ARank>, 2, T> && is_incore_rank_tensor_v<BType<T, BRank>, 2, T>, int> {
+    Section section{"gesv"};
     auto n = A->dim(0);
     auto lda = A->dim(0);
     auto ldb = B->dim(1);
@@ -119,9 +120,7 @@ auto gesv(AType<T, ARank> *A, BType<T, BRank> *B)
     int lwork = n;
     std::vector<int> ipiv(lwork);
 
-    timer::push("gesv");
-    int info = blas::dgesv(n, nrhs, A->data(), lda, ipiv.data(), B->data(), ldb);
-    timer::pop();
+    int info = blas::gesv(n, nrhs, A->data(), lda, ipiv.data(), B->data(), ldb);
     return info;
 }
 

--- a/src/include/einsums/LinearAlgebra.hpp
+++ b/src/include/einsums/LinearAlgebra.hpp
@@ -91,7 +91,7 @@ auto syev(AType<T, ARank> *A, WType<T, WRank> *W) -> std::enable_if_t<is_incore_
 
 template <template <typename, size_t> typename AType, size_t ARank, template <typename, size_t> typename WType, size_t WRank, typename T,
           bool ComputeEigenvectors = true>
-auto heev(AType<T, ARank> *A, WType<typename complex_type<T>::type, WRank> *W)
+auto heev(AType<T, ARank> *A, WType<complex_type_t<T>, WRank> *W)
     -> std::enable_if_t<is_incore_rank_tensor_v<AType<T, ARank>, 2, T> && is_incore_rank_tensor_v<WType<T, WRank>, 1, T> &&
                         is_complex_v<T>> {
     Section section{fmt::format("heev<ComputeEigenvectors={}>", ComputeEigenvectors)};
@@ -101,7 +101,7 @@ auto heev(AType<T, ARank> *A, WType<typename complex_type<T>::type, WRank> *W)
     auto lda = A->stride(0);
     int lwork = 2 * n;
     std::vector<T> work(lwork);
-    std::vector<typename complex_type<T>::type> rwork(3 * n);
+    std::vector<complex_type_t<T>> rwork(3 * n);
 
     blas::heev(ComputeEigenvectors ? 'v' : 'n', 'u', n, A->data(), lda, W->data(), work.data(), lwork, rwork.data());
 }

--- a/src/include/einsums/LinearAlgebra.hpp
+++ b/src/include/einsums/LinearAlgebra.hpp
@@ -15,13 +15,13 @@
 
 namespace einsums::linear_algebra {
 
-// template <size_t, typename> typename AType, size_t Rank, typename T
+// template <typename, size_t> typename AType, size_t Rank, typename T
 
-template <bool TransA, bool TransB, template <size_t, typename> typename AType, template <size_t, typename> typename BType,
-          template <size_t, typename> typename CType, size_t Rank, typename T>
-auto gemm(const T alpha, const AType<Rank, T> &A, const BType<Rank, T> &B, const T beta, CType<Rank, T> *C) ->
-    typename std::enable_if_t<is_incore_rank_tensor_v<AType<Rank, T>, 2, T> && is_incore_rank_tensor_v<BType<Rank, T>, 2, T> &&
-                              is_incore_rank_tensor_v<CType<Rank, T>, 2, T>> {
+template <bool TransA, bool TransB, template <typename, size_t> typename AType, template <typename, size_t> typename BType,
+          template <typename, size_t> typename CType, size_t Rank, typename T>
+auto gemm(const T alpha, const AType<T, Rank> &A, const BType<T, Rank> &B, const T beta, CType<T, Rank> *C) ->
+    typename std::enable_if_t<is_incore_rank_tensor_v<AType<T, Rank>, 2, T> && is_incore_rank_tensor_v<BType<T, Rank>, 2, T> &&
+                              is_incore_rank_tensor_v<CType<T, Rank>, 2, T>> {
     auto m = C->dim(0), n = C->dim(1), k = TransA ? A.dim(0) : A.dim(1);
     auto lda = A.stride(0), ldb = B.stride(0), ldc = C->stride(0);
 
@@ -42,27 +42,27 @@ auto gemm(const T alpha, const AType<Rank, T> &A, const BType<Rank, T> &B, const
  * @param B
  * @param beta
  *
- * @return std::enable_if_t<std::is_base_of_v<Detail::TensorBase<2, double>, AType> &&
- * std::is_base_of_v<Detail::TensorBase<2, double>, BType>,
- * Tensor<2, double>>
+ * @return std::enable_if_t<std::is_base_of_v<Detail::TensorBase<double, 2>, AType> &&
+ * std::is_base_of_v<Detail::TensorBase<double, 2>, BType>,
+ * Tensor<double, 2>>
  *
  */
-template <bool TransA, bool TransB, template <size_t, typename> typename AType, template <size_t, typename> typename BType, size_t Rank,
+template <bool TransA, bool TransB, template <typename, size_t> typename AType, template <typename, size_t> typename BType, size_t Rank,
           typename T>
-auto gemm(const T alpha, const AType<Rank, T> &A, const BType<Rank, T> &B)
-    -> std::enable_if_t<is_incore_rank_tensor_v<AType<Rank, T>, 2, T> && is_incore_rank_tensor_v<BType<Rank, T>, 2, T>, Tensor<2, double>> {
-    Tensor<2, double> C{"gemm result", TransA ? A.dim(1) : A.dim(0), TransB ? B.dim(1) : B.dim(0)};
+auto gemm(const T alpha, const AType<T, Rank> &A, const BType<T, Rank> &B)
+    -> std::enable_if_t<is_incore_rank_tensor_v<AType<T, Rank>, 2, T> && is_incore_rank_tensor_v<BType<T, Rank>, 2, T>, Tensor<T, 2>> {
+    Tensor<T, 2> C{"gemm result", TransA ? A.dim(1) : A.dim(0), TransB ? B.dim(1) : B.dim(0)};
 
     gemm<TransA, TransB>(alpha, A, B, 0.0, &C);
 
     return C;
 }
 
-template <bool TransA, template <size_t, typename> typename AType, template <size_t, typename> typename XType,
-          template <size_t, typename> typename YType, size_t ARank, size_t XYRank, typename T>
-auto gemv(const double alpha, const AType<ARank, T> &A, const XType<XYRank, T> &x, const double beta, YType<XYRank, T> *y)
-    -> std::enable_if_t<is_incore_rank_tensor_v<AType<ARank, T>, 2, T> && is_incore_rank_tensor_v<XType<XYRank, T>, 1, T> &&
-                        is_incore_rank_tensor_v<YType<XYRank, T>, 1, T>> {
+template <bool TransA, template <typename, size_t> typename AType, template <typename, size_t> typename XType,
+          template <typename, size_t> typename YType, size_t ARank, size_t XYRank, typename T>
+auto gemv(const double alpha, const AType<T, ARank> &A, const XType<T, XYRank> &x, const double beta, YType<T, XYRank> *y)
+    -> std::enable_if_t<is_incore_rank_tensor_v<AType<T, ARank>, 2, T> && is_incore_rank_tensor_v<XType<T, XYRank>, 1, T> &&
+                        is_incore_rank_tensor_v<YType<T, XYRank>, 1, T>> {
     auto m = A.dim(0), n = A.dim(1);
     auto lda = A.stride(0);
     auto incx = x.stride(0);
@@ -73,10 +73,10 @@ auto gemv(const double alpha, const AType<ARank, T> &A, const XType<XYRank, T> &
     timer::pop();
 }
 
-template <template <size_t, typename> typename AType, size_t ARank, template <size_t, typename> typename WType, size_t WRank, typename T,
+template <template <typename, size_t> typename AType, size_t ARank, template <typename, size_t> typename WType, size_t WRank, typename T,
           bool ComputeEigenvectors = true>
-auto syev(AType<ARank, T> *A, WType<WRank, T> *W)
-    -> std::enable_if_t<is_incore_rank_tensor_v<AType<ARank, T>, 2, T> && is_incore_rank_tensor_v<WType<WRank, T>, 1, T>> {
+auto syev(AType<T, ARank> *A, WType<T, WRank> *W)
+    -> std::enable_if_t<is_incore_rank_tensor_v<AType<T, ARank>, 2, T> && is_incore_rank_tensor_v<WType<T, WRank>, 1, T>> {
     assert(A->dim(0) == A->dim(1));
 
     auto n = A->dim(0);
@@ -90,9 +90,9 @@ auto syev(AType<ARank, T> *A, WType<WRank, T> *W)
 }
 
 // This assumes column-major ordering!!
-template <template <size_t, typename> typename AType, size_t ARank, template <size_t, typename> typename BType, size_t BRank, typename T>
-auto gesv(AType<ARank, T> *A, BType<BRank, T> *B)
-    -> std::enable_if_t<is_incore_rank_tensor_v<AType<ARank, T>, 2, T> && is_incore_rank_tensor_v<BType<BRank, T>, 2, T>, int> {
+template <template <typename, size_t> typename AType, size_t ARank, template <typename, size_t> typename BType, size_t BRank, typename T>
+auto gesv(AType<T, ARank> *A, BType<T, BRank> *B)
+    -> std::enable_if_t<is_incore_rank_tensor_v<AType<T, ARank>, 2, T> && is_incore_rank_tensor_v<BType<T, BRank>, 2, T>, int> {
     auto n = A->dim(0);
     auto lda = A->dim(0);
     auto ldb = B->dim(1);
@@ -108,21 +108,21 @@ auto gesv(AType<ARank, T> *A, BType<BRank, T> *B)
     return info;
 }
 
-template <template <size_t, typename> typename AType, size_t ARank, typename T, bool ComputeEigenvectors = true>
-auto syev(const AType<ARank, T> &A) ->
-    typename std::enable_if_t<is_incore_rank_tensor_v<AType<ARank, T>, 2, T>, std::tuple<Tensor<2, T>, Tensor<1, T>>> {
+template <template <typename, size_t> typename AType, size_t ARank, typename T, bool ComputeEigenvectors = true>
+auto syev(const AType<T, ARank> &A) ->
+    typename std::enable_if_t<is_incore_rank_tensor_v<AType<T, ARank>, 2, T>, std::tuple<Tensor<T, 2>, Tensor<T, 1>>> {
     assert(A.dim(0) == A.dim(1));
 
-    Tensor<2, double> a = A;
-    Tensor<1, double> w{"eigenvalues", A.dim(0)};
+    Tensor<T, 2> a = A;
+    Tensor<T, 1> w{"eigenvalues", A.dim(0)};
 
     syev<ComputeEigenvectors>(&a, &w);
 
     return std::make_tuple(a, w);
 }
 
-template <template <size_t, typename> typename AType, size_t ARank, typename T = double>
-auto scale(double scale, AType<ARank, T> *A) -> typename std::enable_if_t<is_incore_rank_tensor_v<AType<ARank, T>, ARank, double>> {
+template <template <typename, size_t> typename AType, size_t ARank, typename T = double>
+auto scale(double scale, AType<T, ARank> *A) -> typename std::enable_if_t<is_incore_rank_tensor_v<AType<T, ARank>, ARank, double>> {
     timer::push("scal");
     blas::dscal(A->dim(0) * A->stride(0), scale, A->data(), 1);
     timer::pop();
@@ -146,23 +146,23 @@ auto scale_column(size_t col, double scale, AType *A) -> typename std::enable_if
  * @param alpha The power to take
  * @param cutoff Values below cutoff are considered zero.
  *
- * @return std::enable_if_t<std::is_base_of_v<Detail::TensorBase<2, double>, AType>, AType>
+ * @return std::enable_if_t<std::is_base_of_v<Detail::TensorBase<double, 2>, AType>, AType>
  *
  */
-template <template <size_t, typename> typename AType, size_t ARank, typename T>
-auto pow(const AType<ARank, T> &a, T alpha, T cutoff = std::numeric_limits<T>::epsilon()) ->
-    typename std::enable_if_t<is_incore_rank_tensor_v<AType<ARank, T>, 2, T>, AType<ARank, T>> {
+template <template <typename, size_t> typename AType, size_t ARank, typename T>
+auto pow(const AType<T, ARank> &a, T alpha, T cutoff = std::numeric_limits<T>::epsilon()) ->
+    typename std::enable_if_t<is_incore_rank_tensor_v<AType<T, ARank>, 2, T>, AType<T, ARank>> {
     assert(a.dim(0) == a.dim(1));
 
     size_t n = a.dim(0);
-    Tensor<2> a1 = a;
-    Tensor<2> result{"pow result", a.dim(0), a.dim(1)};
-    Tensor<1> e{"e", n};
+    Tensor<T, 2> a1 = a;
+    Tensor<T, 2> result{"pow result", a.dim(0), a.dim(1)};
+    Tensor<T, 1> e{"e", n};
 
     // Diagonalize
     syev(&a1, &e);
 
-    Tensor<2> a2 = a1;
+    Tensor<T, 2> a2 = a1;
 
     // Determine the largest magnitude of the eigenvalues to use as a scaling factor for the cutoff.
     double max_e = std::fabs(e(n - 1)) > std::fabs(e(0)) ? std::fabs(e(n - 1)) : std::fabs(e(0));
@@ -185,9 +185,9 @@ auto pow(const AType<ARank, T> &a, T alpha, T cutoff = std::numeric_limits<T>::e
     return result;
 }
 
-template <template <size_t, typename> typename Type>
-auto dot(const Type<1, double> &A, const Type<1, double> &B) ->
-    typename std::enable_if_t<std::is_base_of_v<detail::TensorBase<1, double>, Type<1, double>>, double> {
+template <template <typename, size_t> typename Type>
+auto dot(const Type<double, 1> &A, const Type<double, 1> &B) ->
+    typename std::enable_if_t<std::is_base_of_v<detail::TensorBase<double, 1>, Type<double, 1>>, double> {
     assert(A.dim(0) == B.dim(0));
 
     timer::push("dot");
@@ -196,9 +196,9 @@ auto dot(const Type<1, double> &A, const Type<1, double> &B) ->
     return result;
 }
 
-template <template <size_t, typename> typename Type, size_t Rank>
-auto dot(const Type<Rank, double> &A, const Type<Rank, double> &B) ->
-    typename std::enable_if_t<std::is_base_of_v<detail::TensorBase<Rank, double>, Type<Rank, double>>, double> {
+template <template <typename, size_t> typename Type, size_t Rank>
+auto dot(const Type<double, Rank> &A, const Type<double, Rank> &B) ->
+    typename std::enable_if_t<std::is_base_of_v<detail::TensorBase<double, Rank>, Type<double, Rank>>, double> {
     Dim<1> dim{1};
 
     for (size_t i = 0; i < Rank; i++) {
@@ -206,12 +206,13 @@ auto dot(const Type<Rank, double> &A, const Type<Rank, double> &B) ->
         dim[0] *= A.dim(i);
     }
 
-    return dot(TensorView<1>(const_cast<Type<Rank, double> &>(A), dim), TensorView<1>(const_cast<Type<Rank, double> &>(B), dim));
+    return dot(TensorView<double, 1>(const_cast<Type<double, Rank> &>(A), dim),
+               TensorView<double, 1>(const_cast<Type<double, Rank> &>(B), dim));
 }
 
-template <template <size_t, typename> typename Type, size_t Rank>
-auto dot(const Type<Rank, double> &A, const Type<Rank, double> &B, const Type<Rank, double> &C) -> // NOLINT
-    typename std::enable_if_t<std::is_base_of_v<detail::TensorBase<Rank, double>, Type<Rank, double>>, double> {
+template <template <typename, size_t> typename Type, size_t Rank>
+auto dot(const Type<double, Rank> &A, const Type<double, Rank> &B, const Type<double, Rank> &C) -> // NOLINT
+    typename std::enable_if_t<std::is_base_of_v<detail::TensorBase<double, Rank>, Type<double, Rank>>, double> {
     Dim<1> dim{1};
 
     for (size_t i = 0; i < Rank; i++) {
@@ -219,9 +220,9 @@ auto dot(const Type<Rank, double> &A, const Type<Rank, double> &B, const Type<Ra
         dim[0] *= A.dim(i);
     }
 
-    auto vA = TensorView<1>(const_cast<Type<Rank, double> &>(A), dim);
-    auto vB = TensorView<1>(const_cast<Type<Rank, double> &>(B), dim);
-    auto vC = TensorView<1>(const_cast<Type<Rank, double> &>(C), dim);
+    auto vA = TensorView<double, 1>(const_cast<Type<double, Rank> &>(A), dim);
+    auto vB = TensorView<double, 1>(const_cast<Type<double, Rank> &>(B), dim);
+    auto vC = TensorView<double, 1>(const_cast<Type<double, Rank> &>(C), dim);
 
     timer::push("dot3");
     double result = 0.0;
@@ -233,26 +234,26 @@ auto dot(const Type<Rank, double> &A, const Type<Rank, double> &B, const Type<Ra
     return result;
 }
 
-template <template <size_t, typename> typename XType, template <size_t, typename> typename YType, size_t Rank>
-auto axpy(double alpha, const XType<Rank, double> &X, YType<Rank, double> *Y)
-    -> std::enable_if_t<is_incore_rank_tensor_v<XType<Rank, double>, Rank, double> &&
-                        is_incore_rank_tensor_v<YType<Rank, double>, Rank, double>> {
+template <template <typename, size_t> typename XType, template <typename, size_t> typename YType, size_t Rank>
+auto axpy(double alpha, const XType<double, Rank> &X, YType<double, Rank> *Y)
+    -> std::enable_if_t<is_incore_rank_tensor_v<XType<double, Rank>, Rank, double> &&
+                        is_incore_rank_tensor_v<YType<double, Rank>, Rank, double>> {
     timer::push("axpy");
     blas::daxpy(X.dim(0) * X.stride(0), alpha, X.data(), 1, Y->data(), 1);
     timer::pop();
 }
 
-template <template <size_t, typename> typename XYType, size_t XYRank, template <size_t, typename> typename AType, size_t ARank>
-auto ger(double alpha, const XYType<XYRank, double> &X, const XYType<XYRank, double> &Y, AType<ARank, double> *A)
-    -> std::enable_if_t<is_incore_rank_tensor_v<XYType<XYRank, double>, 1, double> &&
-                        is_incore_rank_tensor_v<AType<ARank, double>, 2, double>> {
+template <template <typename, size_t> typename XYType, size_t XYRank, template <typename, size_t> typename AType, size_t ARank>
+auto ger(double alpha, const XYType<double, XYRank> &X, const XYType<double, XYRank> &Y, AType<double, ARank> *A)
+    -> std::enable_if_t<is_incore_rank_tensor_v<XYType<double, XYRank>, 1, double> &&
+                        is_incore_rank_tensor_v<AType<double, ARank>, 2, double>> {
     timer::Timer timer{"ger"};
     blas::dger(X.dim(0), Y.dim(0), alpha, X.data(), X.stride(0), Y.data(), Y.stride(0), A->data(), A->stride(0));
 }
 
-template <template <size_t, typename> typename TensorType, size_t TensorRank>
-auto getrf(TensorType<TensorRank, double> *A, std::vector<int> *pivot)
-    -> std::enable_if_t<is_incore_rank_tensor_v<TensorType<TensorRank, double>, 2, double>, int> {
+template <template <typename, size_t> typename TensorType, size_t TensorRank>
+auto getrf(TensorType<double, TensorRank> *A, std::vector<int> *pivot)
+    -> std::enable_if_t<is_incore_rank_tensor_v<TensorType<double, TensorRank>, 2, double>, int> {
     timer::push("getrf");
     if (pivot->size() < std::min(A->dim(0), A->dim(1))) {
         println("getrf: resizing pivot vector from {} to {}", pivot->size(), std::min(A->dim(0), A->dim(1)));
@@ -270,9 +271,9 @@ auto getrf(TensorType<TensorRank, double> *A, std::vector<int> *pivot)
     return result;
 }
 
-template <template <size_t, typename> typename TensorType, size_t TensorRank>
-auto getri(TensorType<TensorRank, double> *A, const std::vector<int> &pivot)
-    -> std::enable_if_t<is_incore_rank_tensor_v<TensorType<TensorRank, double>, 2, double>, int> {
+template <template <typename, size_t> typename TensorType, size_t TensorRank>
+auto getri(TensorType<double, TensorRank> *A, const std::vector<int> &pivot)
+    -> std::enable_if_t<is_incore_rank_tensor_v<TensorType<double, TensorRank>, 2, double>, int> {
     timer::push("getri");
 
     // Call dgetri once to determine work size
@@ -289,8 +290,8 @@ auto getri(TensorType<TensorRank, double> *A, const std::vector<int> &pivot)
     return result;
 }
 
-template <template <size_t, typename> typename TensorType, size_t TensorRank>
-auto invert(TensorType<TensorRank, double> *A) -> std::enable_if_t<is_incore_rank_tensor_v<TensorType<TensorRank, double>, 2, double>> {
+template <template <typename, size_t> typename TensorType, size_t TensorRank>
+auto invert(TensorType<double, TensorRank> *A) -> std::enable_if_t<is_incore_rank_tensor_v<TensorType<double, TensorRank>, 2, double>> {
     timer::push("invert");
 
     std::vector<int> pivot(A->dim(0));
@@ -317,9 +318,9 @@ auto invert(SmartPtr *A) -> std::enable_if_t<is_smart_pointer_v<SmartPtr>> {
 
 enum class Norm : char { MaxAbs = 'M', One = 'O', Infinity = 'I', Frobenius = 'F', Two = 'F' };
 
-template <template <size_t, typename> typename AType, size_t ARank>
-auto norm(Norm norm_type, const AType<ARank, double> &a) ->
-    typename std::enable_if_t<is_incore_rank_tensor_v<AType<ARank, double>, 2, double>, AType<ARank, double>> {
+template <template <typename, size_t> typename AType, size_t ARank>
+auto norm(Norm norm_type, const AType<double, ARank> &a) ->
+    typename std::enable_if_t<is_incore_rank_tensor_v<AType<double, ARank>, 2, double>, AType<double, ARank>> {
     if (norm_type != Norm::Infinity) {
         return blas::dlange(norm_type, a->dim(0), a->dim(1), a->data(), a->stride(0), nullptr);
     } else {
@@ -328,13 +329,13 @@ auto norm(Norm norm_type, const AType<ARank, double> &a) ->
     }
 }
 
-template <template <size_t, typename> typename AType, size_t ARank>
-auto svd_a(const AType<ARank, double> &_A) ->
-    typename std::enable_if_t<is_incore_rank_tensor_v<AType<ARank, double>, 2, double>,
-                              std::tuple<Tensor<2, double>, Tensor<1, double>, Tensor<2, double>>> {
+template <template <typename, size_t> typename AType, size_t ARank>
+auto svd_a(const AType<double, ARank> &_A) ->
+    typename std::enable_if_t<is_incore_rank_tensor_v<AType<double, ARank>, 2, double>,
+                              std::tuple<Tensor<double, 2>, Tensor<double, 1>, Tensor<double, 2>>> {
     timer::Timer timer{"svd_a"};
     // Calling svd will destroy the original data.
-    Tensor<2> A = _A;
+    Tensor<double, 2> A = _A;
 
     size_t m = A.dim(0);
     size_t n = A.dim(1);

--- a/src/include/einsums/Print.hpp
+++ b/src/include/einsums/Print.hpp
@@ -7,6 +7,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <complex>
 #include <cstring>
 #include <iomanip>
 #include <iostream>
@@ -221,3 +222,67 @@ inline void println_warn(const std::string_view &format, const Ts... ts) {
     std::string message = std::string("WARNING: ") + format.data();
     println(bg(fmt::color::yellow) | fg(fmt::color::black), message, ts...);
 }
+
+FMT_BEGIN_NAMESPACE
+template <class charT>
+struct formatter<std::complex<double>, charT> {
+  private:
+    detail::dynamic_format_specs<char> specs_;
+
+  public:
+    FMT_CONSTEXPR typename basic_format_parse_context<charT>::iterator parse(basic_format_parse_context<charT> &ctx) {
+        using handler_type = detail::dynamic_specs_handler<basic_format_parse_context<charT>>;
+        detail::specs_checker<handler_type> handler(handler_type(specs_, ctx), detail::type::string_type);
+        auto it = parse_format_specs(ctx.begin(), ctx.end(), handler);
+        detail::parse_float_type_spec(specs_, ctx.error_handler());
+        return it;
+    }
+
+    template <class FormatContext>
+    typename FormatContext::iterator format(const std::complex<double> &c, FormatContext &ctx) {
+        detail::handle_dynamic_spec<detail::precision_checker>(specs_.precision, specs_.precision_ref, ctx);
+        auto specs = std::string();
+        if (specs_.precision > 0)
+            specs = fmt::format(".{}", specs_.precision);
+        if (specs_.type == presentation_type::fixed_lower)
+            specs += 'f';
+        auto real = fmt::format(ctx.locale().template get<std::locale>(), fmt::runtime("{:" + specs + "}"), c.real());
+        auto imag = fmt::format(ctx.locale().template get<std::locale>(), fmt::runtime("{:" + specs + "}"), c.imag());
+        auto fill_align_width = std::string();
+        if (specs_.width > 0)
+            fill_align_width = fmt::format(">{}", specs_.width);
+        return format_to(ctx.out(), runtime("{:" + fill_align_width + "}"), fmt::format("({}+{}i)", real, imag));
+    }
+};
+
+template <class charT>
+struct formatter<std::complex<float>, charT> {
+  private:
+    detail::dynamic_format_specs<char> specs_;
+
+  public:
+    FMT_CONSTEXPR typename basic_format_parse_context<charT>::iterator parse(basic_format_parse_context<charT> &ctx) {
+        using handler_type = detail::dynamic_specs_handler<basic_format_parse_context<charT>>;
+        detail::specs_checker<handler_type> handler(handler_type(specs_, ctx), detail::type::string_type);
+        auto it = parse_format_specs(ctx.begin(), ctx.end(), handler);
+        detail::parse_float_type_spec(specs_, ctx.error_handler());
+        return it;
+    }
+
+    template <class FormatContext>
+    typename FormatContext::iterator format(const std::complex<float> &c, FormatContext &ctx) {
+        detail::handle_dynamic_spec<detail::precision_checker>(specs_.precision, specs_.precision_ref, ctx);
+        auto specs = std::string();
+        if (specs_.precision > 0)
+            specs = fmt::format(".{}", specs_.precision);
+        if (specs_.type == presentation_type::fixed_lower)
+            specs += 'f';
+        auto real = fmt::format(ctx.locale().template get<std::locale>(), fmt::runtime("{:" + specs + "}"), c.real());
+        auto imag = fmt::format(ctx.locale().template get<std::locale>(), fmt::runtime("{:" + specs + "}"), c.imag());
+        auto fill_align_width = std::string();
+        if (specs_.width > 0)
+            fill_align_width = fmt::format(">{}", specs_.width);
+        return format_to(ctx.out(), runtime("{:" + fill_align_width + "}"), fmt::format("({}+{}i)", real, imag));
+    }
+};
+FMT_END_NAMESPACE

--- a/src/include/einsums/Print.hpp
+++ b/src/include/einsums/Print.hpp
@@ -14,13 +14,6 @@
 #include <stdexcept>
 #include <string_view>
 
-namespace einsums {
-
-// Forward declare the Tensor object for printing purposes
-template <size_t Rank, typename T>
-struct Tensor;
-} // namespace einsums
-
 namespace print {
 
 /** Adds spaces to the global indentation counter. */
@@ -65,7 +58,7 @@ void println(const std::string &oss);
 //
 namespace detail {
 template <typename T>
-constexpr const auto &RawTypeName() {
+constexpr auto RawTypeName() -> const auto & {
 #ifdef _MSC_VER
     return __FUNCSIG__;
 #else
@@ -78,7 +71,7 @@ struct RawTypeNameFormat {
 };
 
 // Returns `false` on failure.
-inline constexpr bool GetRawTypeNameFormat(RawTypeNameFormat *format) {
+inline constexpr auto GetRawTypeNameFormat(RawTypeNameFormat *format) -> bool {
     const auto &str = RawTypeName<int>();
     for (std::size_t i = 0;; i++) {
         if (str[i] == 'i' && str[i + 1] == 'n' && str[i + 2] == 't') {

--- a/src/include/einsums/Print.hpp
+++ b/src/include/einsums/Print.hpp
@@ -242,8 +242,9 @@ struct formatter<std::complex<double>, charT> {
     typename FormatContext::iterator format(const std::complex<double> &c, FormatContext &ctx) {
         detail::handle_dynamic_spec<detail::precision_checker>(specs_.precision, specs_.precision_ref, ctx);
         auto specs = std::string();
+        specs += "+";
         if (specs_.precision > 0)
-            specs = fmt::format(".{}", specs_.precision);
+            specs += fmt::format(".{}", specs_.precision);
         if (specs_.type == presentation_type::fixed_lower)
             specs += 'f';
         auto real = fmt::format(ctx.locale().template get<std::locale>(), fmt::runtime("{:" + specs + "}"), c.real());
@@ -251,7 +252,7 @@ struct formatter<std::complex<double>, charT> {
         auto fill_align_width = std::string();
         if (specs_.width > 0)
             fill_align_width = fmt::format(">{}", specs_.width);
-        return format_to(ctx.out(), runtime("{:" + fill_align_width + "}"), fmt::format("({}+{}i)", real, imag));
+        return format_to(ctx.out(), runtime("{:" + fill_align_width + "}"), fmt::format("({} {}i)", real, imag));
     }
 };
 
@@ -273,8 +274,9 @@ struct formatter<std::complex<float>, charT> {
     typename FormatContext::iterator format(const std::complex<float> &c, FormatContext &ctx) {
         detail::handle_dynamic_spec<detail::precision_checker>(specs_.precision, specs_.precision_ref, ctx);
         auto specs = std::string();
+        specs += "+";
         if (specs_.precision > 0)
-            specs = fmt::format(".{}", specs_.precision);
+            specs += fmt::format(".{}", specs_.precision);
         if (specs_.type == presentation_type::fixed_lower)
             specs += 'f';
         auto real = fmt::format(ctx.locale().template get<std::locale>(), fmt::runtime("{:" + specs + "}"), c.real());
@@ -282,7 +284,7 @@ struct formatter<std::complex<float>, charT> {
         auto fill_align_width = std::string();
         if (specs_.width > 0)
             fill_align_width = fmt::format(">{}", specs_.width);
-        return format_to(ctx.out(), runtime("{:" + fill_align_width + "}"), fmt::format("({}+{}i)", real, imag));
+        return format_to(ctx.out(), runtime("{:" + fill_align_width + "}"), fmt::format("({} {}i)", real, imag));
     }
 };
 FMT_END_NAMESPACE

--- a/src/include/einsums/STL.hpp
+++ b/src/include/einsums/STL.hpp
@@ -326,6 +326,25 @@ template <typename T>
 inline constexpr bool is_smart_pointer_v = is_smart_pointer<T>::value;
 
 template <typename T>
+struct is_complex_t : public std::false_type {};
+
+template <typename T>
+struct is_complex_t<std::complex<T>> : public std::true_type {};
+
+template <typename T>
+inline constexpr bool is_complex_v = is_complex_t<T>::value;
+
+template <typename T>
+struct complex_type {
+    using type = void;
+};
+
+template <typename T>
+struct complex_type<std::complex<T>> {
+    using type = T;
+};
+
+template <typename T>
 struct CircularBuffer {
     explicit CircularBuffer(size_t size) : _buffer(std::unique_ptr<T[]>(new T[size])), _max_size(size) {} // NOLINT
 

--- a/src/include/einsums/STL.hpp
+++ b/src/include/einsums/STL.hpp
@@ -336,13 +336,16 @@ inline constexpr bool is_complex_v = is_complex_t<T>::value;
 
 template <typename T>
 struct complex_type {
-    using type = void;
+    using type = T;
 };
 
 template <typename T>
 struct complex_type<std::complex<T>> {
     using type = T;
 };
+
+template <typename T>
+using complex_type_t = typename complex_type<T>::type;
 
 template <typename T>
 struct CircularBuffer {

--- a/src/include/einsums/STL.hpp
+++ b/src/include/einsums/STL.hpp
@@ -294,11 +294,11 @@ struct DiskTensor;
 template <size_t ViewRank, size_t Rank, typename T>
 struct DiskView;
 
-template <typename D, size_t Rank, typename T = double>
+template <typename D, size_t Rank, typename T>
 struct is_incore_rank_tensor
     : public std::bool_constant<std::is_same_v<std::decay_t<D>, Tensor<Rank, T>> || std::is_same_v<std::decay_t<D>, TensorView<Rank, T>>> {
 };
-template <typename D, size_t Rank, typename T = double>
+template <typename D, size_t Rank, typename T>
 inline constexpr bool is_incore_rank_tensor_v = is_incore_rank_tensor<D, Rank, T>::value;
 
 template <typename D, size_t Rank, size_t ViewRank = Rank, typename T = double>

--- a/src/include/einsums/STL.hpp
+++ b/src/include/einsums/STL.hpp
@@ -282,28 +282,28 @@ struct c_unique {
 template <class T>
 using c_unique_t = typename c_unique<T>::type;
 
-template <size_t Rank, typename T>
+template <typename T, size_t Rank>
 struct Tensor;
 
-template <size_t Rank, typename T>
+template <typename T, size_t Rank>
 struct TensorView;
 
-template <size_t Rank, typename T>
+template <typename T, size_t Rank>
 struct DiskTensor;
 
-template <size_t ViewRank, size_t Rank, typename T>
+template <typename T, size_t ViewRank, size_t Rank>
 struct DiskView;
 
 template <typename D, size_t Rank, typename T>
 struct is_incore_rank_tensor
-    : public std::bool_constant<std::is_same_v<std::decay_t<D>, Tensor<Rank, T>> || std::is_same_v<std::decay_t<D>, TensorView<Rank, T>>> {
+    : public std::bool_constant<std::is_same_v<std::decay_t<D>, Tensor<T, Rank>> || std::is_same_v<std::decay_t<D>, TensorView<T, Rank>>> {
 };
 template <typename D, size_t Rank, typename T>
 inline constexpr bool is_incore_rank_tensor_v = is_incore_rank_tensor<D, Rank, T>::value;
 
 template <typename D, size_t Rank, size_t ViewRank = Rank, typename T = double>
 struct is_ondisk_tensor
-    : public std::bool_constant<std::is_same_v<D, DiskTensor<Rank, T>> || std::is_same_v<D, DiskView<ViewRank, Rank, T>>> {};
+    : public std::bool_constant<std::is_same_v<D, DiskTensor<T, Rank>> || std::is_same_v<D, DiskView<T, ViewRank, Rank>>> {};
 template <typename D, size_t Rank, size_t ViewRank = Rank, typename T = double>
 inline constexpr bool is_ondisk_tensor_v = is_ondisk_tensor<D, Rank, ViewRank, T>::value;
 

--- a/src/include/einsums/Tensor.hpp
+++ b/src/include/einsums/Tensor.hpp
@@ -67,8 +67,8 @@ using Count = detail::Array<detail::CountType, Rank>;
 
 using Range = detail::Array<detail::RangeType, 2>;
 
-struct All {};
-
+struct All_t {};
+static struct All_t All;
 } // namespace einsums
 
 template <size_t Rank>
@@ -335,7 +335,7 @@ struct Tensor final : public detail::TensorBase<T, Rank> {
 
     template <typename... MultiIndex>
     auto operator()(MultiIndex... index) const
-        -> std::enable_if_t<count_of_type<All, MultiIndex...>() == 0 && count_of_type<Range, MultiIndex...>() == 0, const T &> {
+        -> std::enable_if_t<count_of_type<All_t, MultiIndex...>() == 0 && count_of_type<Range, MultiIndex...>() == 0, const T &> {
         assert(sizeof...(MultiIndex) == _dims.size());
         auto index_list = {static_cast<size_t>(index)...};
         size_t ordinal = std::inner_product(index_list.begin(), index_list.end(), _strides.begin(), 0);
@@ -344,7 +344,7 @@ struct Tensor final : public detail::TensorBase<T, Rank> {
 
     template <typename... MultiIndex>
     auto operator()(MultiIndex... index)
-        -> std::enable_if_t<count_of_type<All, MultiIndex...>() == 0 && count_of_type<Range, MultiIndex...>() == 0, T &> {
+        -> std::enable_if_t<count_of_type<All_t, MultiIndex...>() == 0 && count_of_type<Range, MultiIndex...>() == 0, T &> {
         assert(sizeof...(MultiIndex) == _dims.size());
         auto index_list = {static_cast<size_t>(index)...};
         size_t ordinal = std::inner_product(index_list.begin(), index_list.end(), _strides.begin(), 0);
@@ -354,8 +354,8 @@ struct Tensor final : public detail::TensorBase<T, Rank> {
     // WARNING: Chances are this function will not work if you mix All{}, Range{} and explicit indexes.
     template <typename... MultiIndex>
     auto operator()(MultiIndex... index)
-        -> std::enable_if_t<count_of_type<All, MultiIndex...>() >= 1,
-                            TensorView<T, count_of_type<All, MultiIndex...>() + count_of_type<Range, MultiIndex...>()>> {
+        -> std::enable_if_t<count_of_type<All_t, MultiIndex...>() >= 1,
+                            TensorView<T, count_of_type<All_t, MultiIndex...>() + count_of_type<Range, MultiIndex...>()>> {
         // Construct a TensorView using the indices provided as the starting point for the view.
         // e.g.:
         //    Tensor T{"Big Tensor", 7, 7, 7, 7};
@@ -364,15 +364,15 @@ struct Tensor final : public detail::TensorBase<T, Rank> {
         const auto &indices = std::forward_as_tuple(index...);
 
         Offset<Rank> offsets;
-        Stride<count_of_type<All, MultiIndex...>() + count_of_type<Range, MultiIndex...>()> strides{};
-        Dim<count_of_type<All, MultiIndex...>() + count_of_type<Range, MultiIndex...>()> dims{};
+        Stride<count_of_type<All_t, MultiIndex...>() + count_of_type<Range, MultiIndex...>()> strides{};
+        Dim<count_of_type<All_t, MultiIndex...>() + count_of_type<Range, MultiIndex...>()> dims{};
 
         int counter{0};
         for_sequence<sizeof...(MultiIndex)>([&](auto i) {
             // println("looking at {}", i);
             if constexpr (std::is_convertible_v<std::tuple_element_t<i, std::tuple<MultiIndex...>>, size_t>) {
                 offsets[i] = std::get<i>(indices);
-            } else if constexpr (std::is_same_v<All, std::tuple_element_t<i, std::tuple<MultiIndex...>>>) {
+            } else if constexpr (std::is_same_v<All_t, std::tuple_element_t<i, std::tuple<MultiIndex...>>>) {
                 strides[counter] = _strides[i];
                 dims[counter] = _dims[i];
                 counter++;
@@ -393,8 +393,8 @@ struct Tensor final : public detail::TensorBase<T, Rank> {
         // println(dims);
         // println(strides);
 
-        return TensorView<T, count_of_type<All, MultiIndex...>() + count_of_type<Range, MultiIndex...>()>{*this, std::move(dims), offsets,
-                                                                                                          strides};
+        return TensorView<T, count_of_type<All_t, MultiIndex...>() + count_of_type<Range, MultiIndex...>()>{*this, std::move(dims), offsets,
+                                                                                                            strides};
     }
 
     template <typename... MultiIndex>
@@ -1211,11 +1211,11 @@ struct DiskTensor final : public detail::TensorBase<T, Rank> {
     // Range is not inclusive. Range{10, 11} === size of 1
     template <typename... MultiIndex>
     auto operator()(MultiIndex... index)
-        -> std::enable_if_t<count_of_type<All, MultiIndex...>() + count_of_type<Range, MultiIndex...>() != 0,
-                            DiskView<T, count_of_type<All, MultiIndex...>() + count_of_type<Range, MultiIndex...>(), Rank>> {
+        -> std::enable_if_t<count_of_type<All_t, MultiIndex...>() + count_of_type<Range, MultiIndex...>() != 0,
+                            DiskView<T, count_of_type<All_t, MultiIndex...>() + count_of_type<Range, MultiIndex...>(), Rank>> {
         // Get positions of All
         auto all_positions =
-            get_array_from_tuple<std::array<int, count_of_type<All, MultiIndex...>()>>(positions_of_type<All, MultiIndex...>());
+            get_array_from_tuple<std::array<int, count_of_type<All_t, MultiIndex...>()>>(positions_of_type<All_t, MultiIndex...>());
         auto index_positions =
             get_array_from_tuple<std::array<int, count_of_type<size_t, MultiIndex...>()>>(positions_of_type<size_t, MultiIndex...>());
         auto range_positions =
@@ -1231,7 +1231,7 @@ struct DiskTensor final : public detail::TensorBase<T, Rank> {
         std::fill(counts.begin(), counts.end(), 1.0);
 
         // Need the dim of the smaller tensor
-        Dim<count_of_type<All, MultiIndex...>() + count_of_type<Range, MultiIndex...>()> dims_all{};
+        Dim<count_of_type<All_t, MultiIndex...>() + count_of_type<Range, MultiIndex...>()> dims_all{};
 
         for (auto [i, value] : enumerate(index_positions)) {
             // printf("i, value: %d %d\n", i, value);
@@ -1256,17 +1256,17 @@ struct DiskTensor final : public detail::TensorBase<T, Rank> {
             }
         }
 
-        return DiskView<T, count_of_type<All, MultiIndex...>() + count_of_type<Range, MultiIndex...>(), Rank>(*this, dims_all, counts,
-                                                                                                              offsets, strides);
+        return DiskView<T, count_of_type<All_t, MultiIndex...>() + count_of_type<Range, MultiIndex...>(), Rank>(*this, dims_all, counts,
+                                                                                                                offsets, strides);
     }
 
     template <typename... MultiIndex>
     auto operator()(MultiIndex... index) const
-        -> std::enable_if_t<count_of_type<All, MultiIndex...>() + count_of_type<Range, MultiIndex...>() != 0,
-                            const DiskView<T, count_of_type<All, MultiIndex...>() + count_of_type<Range, MultiIndex...>(), Rank>> {
+        -> std::enable_if_t<count_of_type<All_t, MultiIndex...>() + count_of_type<Range, MultiIndex...>() != 0,
+                            const DiskView<T, count_of_type<All_t, MultiIndex...>() + count_of_type<Range, MultiIndex...>(), Rank>> {
         // Get positions of All
         auto all_positions =
-            get_array_from_tuple<std::array<int, count_of_type<All, MultiIndex...>()>>(positions_of_type<All, MultiIndex...>());
+            get_array_from_tuple<std::array<int, count_of_type<All_t, MultiIndex...>()>>(positions_of_type<All_t, MultiIndex...>());
         auto index_positions =
             get_array_from_tuple<std::array<int, count_of_type<size_t, MultiIndex...>()>>(positions_of_type<size_t, MultiIndex...>());
         auto range_positions =
@@ -1282,7 +1282,7 @@ struct DiskTensor final : public detail::TensorBase<T, Rank> {
         std::fill(counts.begin(), counts.end(), 1.0);
 
         // Need the dim of the smaller tensor
-        Dim<count_of_type<All, MultiIndex...>() + count_of_type<Range, MultiIndex...>()> dims_all{};
+        Dim<count_of_type<All_t, MultiIndex...>() + count_of_type<Range, MultiIndex...>()> dims_all{};
 
         for (auto [i, value] : enumerate(index_positions)) {
             // printf("i, value: %d %d\n", i, value);
@@ -1307,8 +1307,8 @@ struct DiskTensor final : public detail::TensorBase<T, Rank> {
             }
         }
 
-        return DiskView<T, count_of_type<All, MultiIndex...>() + count_of_type<Range, MultiIndex...>(), Rank>(*this, dims_all, counts,
-                                                                                                              offsets, strides);
+        return DiskView<T, count_of_type<All_t, MultiIndex...>() + count_of_type<Range, MultiIndex...>(), Rank>(*this, dims_all, counts,
+                                                                                                                offsets, strides);
     }
 
   private:

--- a/src/include/einsums/Tensor.hpp
+++ b/src/include/einsums/Tensor.hpp
@@ -1378,6 +1378,8 @@ TensorView(std::string, Tensor<T, OtherRank> &, const Dim<Rank> &, Args...) -> T
 
 template <typename... Dims>
 DiskTensor(h5::fd_t &file, std::string name, Dims... dims) -> DiskTensor<double, sizeof...(Dims)>;
+
+// Supposedly C++20 will allow template deduction guides for template aliases. i.e. Dim, Stride, Offset, Count, Range.
 #endif
 
 } // namespace einsums

--- a/src/include/einsums/Tensor.hpp
+++ b/src/include/einsums/Tensor.hpp
@@ -913,7 +913,7 @@ auto create_random_tensor(const std::string &name, MultiIndex... index) -> Tenso
             return T{static_cast<double>(unif(re)), static_cast<double>(unif(re))};
         });
     } else {
-        std::generate(A.vector_data().begin(), A.vector_data().end(), [&]() { return T{unif(re)}; });
+        std::generate(A.vector_data().begin(), A.vector_data().end(), [&]() { return static_cast<T>(unif(re)); });
     }
     return A;
 }

--- a/src/include/einsums/TensorAlgebra.hpp
+++ b/src/include/einsums/TensorAlgebra.hpp
@@ -148,13 +148,13 @@ constexpr auto _unique_find_type_with_position() {
     }
 }
 
-template <template <size_t, typename> typename TensorType, size_t Rank, typename... Args, std::size_t... I, typename T = double>
-auto get_dim_ranges_for(const TensorType<Rank, T> &tensor, const std::tuple<Args...> &args, std::index_sequence<I...>) {
+template <template <typename, size_t> typename TensorType, size_t Rank, typename... Args, std::size_t... I, typename T = double>
+auto get_dim_ranges_for(const TensorType<T, Rank> &tensor, const std::tuple<Args...> &args, std::index_sequence<I...>) {
     return std::tuple{ranges::views::ints(0, (int)tensor.dim(std::get<2 * I + 1>(args)))...};
 }
 
-template <template <size_t, typename> typename TensorType, size_t Rank, typename... Args, std::size_t... I, typename T = double>
-auto get_dim_for(const TensorType<Rank, T> &tensor, const std::tuple<Args...> &args, std::index_sequence<I...>) {
+template <template <typename, size_t> typename TensorType, size_t Rank, typename... Args, std::size_t... I, typename T = double>
+auto get_dim_for(const TensorType<T, Rank> &tensor, const std::tuple<Args...> &args, std::index_sequence<I...>) {
     return std::tuple{tensor.dim(std::get<2 * I + 1>(args))...};
 }
 
@@ -203,13 +203,13 @@ constexpr auto unique_find_type_with_position(const std::tuple<Ts...> &, const s
     return _unique_find_type_with_position<std::tuple<Ts...>, Us...>(std::make_index_sequence<sizeof...(Ts)>{});
 }
 
-template <template <size_t, typename> typename TensorType, size_t Rank, typename... Args, typename T = double>
-auto get_dim_ranges_for(const TensorType<Rank, T> &tensor, const std::tuple<Args...> &args) {
+template <template <typename, size_t> typename TensorType, size_t Rank, typename... Args, typename T = double>
+auto get_dim_ranges_for(const TensorType<T, Rank> &tensor, const std::tuple<Args...> &args) {
     return detail::get_dim_ranges_for(tensor, args, std::make_index_sequence<sizeof...(Args) / 2>{});
 }
 
-template <template <size_t, typename> typename TensorType, size_t Rank, typename... Args, typename T = double>
-auto get_dim_for(const TensorType<Rank, T> &tensor, const std::tuple<Args...> &args) {
+template <template <typename, size_t> typename TensorType, size_t Rank, typename... Args, typename T = double>
+auto get_dim_for(const TensorType<T, Rank> &tensor, const std::tuple<Args...> &args) {
     return detail::get_dim_for(tensor, args, std::make_index_sequence<sizeof...(Args) / 2>{});
 }
 
@@ -315,13 +315,13 @@ constexpr auto is_same_ordering(const std::tuple<PositionsInX...> &positions_in_
         return _is_same_ordering(positions_in_x, positions_in_y, std::make_index_sequence<sizeof...(PositionsInX) / 2>{});
 }
 
-template <template <size_t, typename> typename XType, size_t XRank, typename... PositionsInX, std::size_t... I, typename T = double>
-constexpr auto product_dims(const std::tuple<PositionsInX...> &indices, const XType<XRank, T> &X, std::index_sequence<I...>) -> size_t {
+template <template <typename, size_t> typename XType, size_t XRank, typename... PositionsInX, std::size_t... I, typename T = double>
+constexpr auto product_dims(const std::tuple<PositionsInX...> &indices, const XType<T, XRank> &X, std::index_sequence<I...>) -> size_t {
     return (X.dim(std::get<2 * I + 1>(indices)) * ... * 1);
 }
 
-template <template <size_t, typename> typename XType, size_t XRank, typename... PositionsInX, std::size_t... I, typename T = double>
-constexpr auto is_same_dims(const std::tuple<PositionsInX...> &indices, const XType<XRank, T> &X, std::index_sequence<I...>) -> bool {
+template <template <typename, size_t> typename XType, size_t XRank, typename... PositionsInX, std::size_t... I, typename T = double>
+constexpr auto is_same_dims(const std::tuple<PositionsInX...> &indices, const XType<T, XRank> &X, std::index_sequence<I...>) -> bool {
     return ((X.dim(std::get<1>(indices)) == X.dim(std::get<2 * I + 1>(indices))) && ... && 1);
 }
 
@@ -330,18 +330,18 @@ constexpr auto same_indices(std::index_sequence<I...>) {
     return (std::is_same_v<std::tuple_element_t<I, LHS>, std::tuple_element_t<I, RHS>> && ...);
 }
 
-template <template <size_t, typename> typename XType, size_t XRank, typename... PositionsInX, typename T = double>
-constexpr auto product_dims(const std::tuple<PositionsInX...> &indices, const XType<XRank, T> &X) -> size_t {
+template <template <typename, size_t> typename XType, size_t XRank, typename... PositionsInX, typename T = double>
+constexpr auto product_dims(const std::tuple<PositionsInX...> &indices, const XType<T, XRank> &X) -> size_t {
     return detail::product_dims(indices, X, std::make_index_sequence<sizeof...(PositionsInX) / 2>());
 }
 
-template <template <size_t, typename> typename XType, size_t XRank, typename... PositionsInX, typename T = double>
-constexpr auto is_same_dims(const std::tuple<PositionsInX...> &indices, const XType<XRank, T> &X) -> size_t {
+template <template <typename, size_t> typename XType, size_t XRank, typename... PositionsInX, typename T = double>
+constexpr auto is_same_dims(const std::tuple<PositionsInX...> &indices, const XType<T, XRank> &X) -> size_t {
     return detail::is_same_dims(indices, X, std::make_index_sequence<sizeof...(PositionsInX) / 2>());
 }
 
-template <template <size_t, typename> typename XType, size_t XRank, typename... PositionsInX, typename T = double>
-constexpr auto last_stride(const std::tuple<PositionsInX...> &indices, const XType<XRank, T> &X) -> size_t {
+template <template <typename, size_t> typename XType, size_t XRank, typename... PositionsInX, typename T = double>
+constexpr auto last_stride(const std::tuple<PositionsInX...> &indices, const XType<T, XRank> &X) -> size_t {
     return X.stride(std::get<sizeof...(PositionsInX) - 1>(indices));
 }
 
@@ -355,15 +355,15 @@ constexpr auto same_indices() {
 
 template <typename T, typename... CUniqueIndices, typename... AUniqueIndices, typename... BUniqueIndices, typename... LinkUniqueIndices,
           typename... CIndices, typename... AIndices, typename... BIndices, typename... TargetDims, typename... LinkDims,
-          typename... TargetPositionInC, typename... LinkPositionInLink, template <size_t, typename> typename CType, size_t CRank,
-          template <size_t, typename> typename AType, size_t ARank, template <size_t, typename> typename BType, size_t BRank>
+          typename... TargetPositionInC, typename... LinkPositionInLink, template <typename, size_t> typename CType, size_t CRank,
+          template <typename, size_t> typename AType, size_t ARank, template <typename, size_t> typename BType, size_t BRank>
 void einsum_generic_algorithm(const std::tuple<CUniqueIndices...> &C_unique, const std::tuple<AUniqueIndices...> & /*A_unique*/,
                               const std::tuple<BUniqueIndices...> & /*B_unique*/, const std::tuple<LinkUniqueIndices...> &link_unique,
                               const std::tuple<CIndices...> & /*C_indices*/, const std::tuple<AIndices...> & /*A_indices*/,
                               const std::tuple<BIndices...> & /*B_indices*/, const std::tuple<TargetDims...> &target_dims,
                               const std::tuple<LinkDims...> &link_dims, const std::tuple<TargetPositionInC...> &target_position_in_C,
-                              const std::tuple<LinkPositionInLink...> &link_position_in_link, const T C_prefactor, CType<CRank, T> *C,
-                              const T AB_prefactor, const AType<ARank, T> &A, const BType<BRank, T> &B) {
+                              const std::tuple<LinkPositionInLink...> &link_position_in_link, const T C_prefactor, CType<T, CRank> *C,
+                              const T AB_prefactor, const AType<T, ARank> &A, const BType<T, BRank> &B) {
     timer::push("generic algorithm");
 
     auto view = std::apply(ranges::views::cartesian_product, target_dims);
@@ -453,14 +453,14 @@ void einsum_generic_algorithm(const std::tuple<CUniqueIndices...> &C_unique, con
     timer::pop();
 }
 
-template <bool OnlyUseGenericAlgorithm, template <size_t, typename> typename AType, size_t ARank,
-          template <size_t, typename> typename BType, size_t BRank, template <size_t, typename> typename CType, size_t CRank,
+template <bool OnlyUseGenericAlgorithm, template <typename, size_t> typename AType, size_t ARank,
+          template <typename, size_t> typename BType, size_t BRank, template <typename, size_t> typename CType, size_t CRank,
           typename... CIndices, typename... AIndices, typename... BIndices, typename T = double>
-auto einsum(const T C_prefactor, const std::tuple<CIndices...> & /*Cs*/, CType<CRank, T> *C, const T AB_prefactor,
-            const std::tuple<AIndices...> & /*As*/, const AType<ARank, T> &A, const std::tuple<BIndices...> & /*Bs*/,
-            const BType<BRank, T> &B) -> std::enable_if_t<std::is_base_of_v<::einsums::detail::TensorBase<ARank, T>, AType<ARank, T>> &&
-                                                          std::is_base_of_v<::einsums::detail::TensorBase<BRank, T>, BType<BRank, T>> &&
-                                                          std::is_base_of_v<::einsums::detail::TensorBase<CRank, T>, CType<CRank, T>>> {
+auto einsum(const T C_prefactor, const std::tuple<CIndices...> & /*Cs*/, CType<T, CRank> *C, const T AB_prefactor,
+            const std::tuple<AIndices...> & /*As*/, const AType<T, ARank> &A, const std::tuple<BIndices...> & /*Bs*/,
+            const BType<T, BRank> &B) -> std::enable_if_t<std::is_base_of_v<::einsums::detail::TensorBase<T, ARank>, AType<T, ARank>> &&
+                                                          std::is_base_of_v<::einsums::detail::TensorBase<T, BRank>, BType<T, BRank>> &&
+                                                          std::is_base_of_v<::einsums::detail::TensorBase<T, CRank>, CType<T, CRank>>> {
     print::Indent _indent;
 
     constexpr auto A_indices = std::tuple<AIndices...>();
@@ -595,7 +595,7 @@ auto einsum(const T C_prefactor, const std::tuple<CIndices...> & /*Cs*/, CType<C
             if constexpr (swap_AB)
                 std::swap(dC[0], dC[1]);
 
-            TensorView<2, T> tC{*C, dC};
+            TensorView<T, 2> tC{*C, dC};
 
             if (C_prefactor != T{1.0})
                 linear_algebra::scale(C_prefactor, C);
@@ -643,9 +643,9 @@ auto einsum(const T C_prefactor, const std::tuple<CIndices...> & /*Cs*/, CType<C
                         dB[0] = product_dims(link_position_in_A, A);
                         dC[0] = product_dims(A_target_position_in_C, *C);
 
-                        const TensorView<2, T> tA{const_cast<AType<ARank, T> &>(A), dA};
-                        const TensorView<1, T> tB{const_cast<BType<BRank, T> &>(B), dB};
-                        TensorView<1, T> tC{*C, dC};
+                        const TensorView<T, 2> tA{const_cast<AType<T, ARank> &>(A), dA};
+                        const TensorView<T, 1> tB{const_cast<BType<T, BRank> &>(B), dB};
+                        TensorView<T, 1> tC{*C, dC};
 
                         if constexpr (transpose_A) {
                             linear_algebra::gemv<true>(AB_prefactor, tA, tB, C_prefactor, &tC);
@@ -695,8 +695,8 @@ auto einsum(const T C_prefactor, const std::tuple<CIndices...> & /*Cs*/, CType<C
                             std::swap(sC[0], sC[1]);
                         }
 
-                        TensorView<2, T> tC{*C, dC, sC};
-                        const TensorView<2, T> tA{const_cast<AType<ARank, T> &>(A), dA, sA}, tB{const_cast<BType<BRank, T> &>(B), dB, sB};
+                        TensorView<T, 2> tC{*C, dC, sC};
+                        const TensorView<T, 2> tA{const_cast<AType<T, ARank> &>(A), dA, sA}, tB{const_cast<BType<T, BRank> &>(B), dB, sB};
 
                         // println("--------------------");
                         // println(*C);
@@ -754,15 +754,15 @@ auto einsum(const T C_prefactor, const std::tuple<CIndices...> & /*Cs*/, CType<C
 
 } // namespace detail
 
-template <template <size_t, typename> typename AType, size_t ARank, template <size_t, typename> typename BType, size_t BRank,
-          template <size_t, typename> typename CType, size_t CRank, typename... CIndices, typename... AIndices, typename... BIndices,
+template <template <typename, size_t> typename AType, size_t ARank, template <typename, size_t> typename BType, size_t BRank,
+          template <typename, size_t> typename CType, size_t CRank, typename... CIndices, typename... AIndices, typename... BIndices,
           typename U, typename T = double>
-auto einsum(const U UC_prefactor, const std::tuple<CIndices...> &C_indices, CType<CRank, T> *C, const U UAB_prefactor,
-            const std::tuple<AIndices...> &A_indices, const AType<ARank, T> &A, const std::tuple<BIndices...> &B_indices,
-            const BType<BRank, T> &B)
-    -> std::enable_if_t<std::is_base_of_v<::einsums::detail::TensorBase<ARank, T>, AType<ARank, T>> &&
-                        std::is_base_of_v<::einsums::detail::TensorBase<BRank, T>, BType<BRank, T>> &&
-                        std::is_base_of_v<::einsums::detail::TensorBase<CRank, T>, CType<CRank, T>> && std::is_arithmetic_v<U>> {
+auto einsum(const U UC_prefactor, const std::tuple<CIndices...> &C_indices, CType<T, CRank> *C, const U UAB_prefactor,
+            const std::tuple<AIndices...> &A_indices, const AType<T, ARank> &A, const std::tuple<BIndices...> &B_indices,
+            const BType<T, BRank> &B)
+    -> std::enable_if_t<std::is_base_of_v<::einsums::detail::TensorBase<T, ARank>, AType<T, ARank>> &&
+                        std::is_base_of_v<::einsums::detail::TensorBase<T, BRank>, BType<T, BRank>> &&
+                        std::is_base_of_v<::einsums::detail::TensorBase<T, CRank>, CType<T, CRank>> && std::is_arithmetic_v<U>> {
     Section section(FP_ZERO != std::fpclassify(UC_prefactor)
                         ? fmt::format(R"(einsum: "{}"{} = {} "{}"{} * "{}"{} + {} "{}"{})", C->name(), print_tuple_no_type(C_indices),
                                       UAB_prefactor, A.name(), print_tuple_no_type(A_indices), B.name(), print_tuple_no_type(B_indices),
@@ -775,7 +775,7 @@ auto einsum(const U UC_prefactor, const std::tuple<CIndices...> &C_indices, CTyp
 
 #if defined(EINSUMS_CONTINUOUSLY_TEST_EINSUM)
     // Clone C into a new tensor
-    Tensor<CRank, T> testC{C->dims()};
+    Tensor<T, CRank> testC{C->dims()};
     testC = *C;
 
     // Perform the einsum using only the generic algorithm
@@ -974,12 +974,12 @@ auto einsum(const std::tuple<CIndices...> &C_indices, CType *C, const std::tuple
 //
 // sort algorithm
 //
-template <template <size_t, typename> typename AType, size_t ARank, template <size_t, typename> typename CType, size_t CRank,
+template <template <typename, size_t> typename AType, size_t ARank, template <typename, size_t> typename CType, size_t CRank,
           typename... CIndices, typename... AIndices, typename U, typename T = double>
-auto sort(const U UC_prefactor, const std::tuple<CIndices...> &C_indices, CType<CRank, T> *C, const U UA_prefactor,
-          const std::tuple<AIndices...> &A_indices, const AType<ARank, T> &A)
-    -> std::enable_if_t<std::is_base_of_v<::einsums::detail::TensorBase<CRank, T>, CType<CRank, T>> &&
-                        std::is_base_of_v<::einsums::detail::TensorBase<ARank, T>, AType<ARank, T>> &&
+auto sort(const U UC_prefactor, const std::tuple<CIndices...> &C_indices, CType<T, CRank> *C, const U UA_prefactor,
+          const std::tuple<AIndices...> &A_indices, const AType<T, ARank> &A)
+    -> std::enable_if_t<std::is_base_of_v<::einsums::detail::TensorBase<T, CRank>, CType<T, CRank>> &&
+                        std::is_base_of_v<::einsums::detail::TensorBase<T, ARank>, AType<T, ARank>> &&
                         sizeof...(CIndices) == sizeof...(AIndices) && sizeof...(CIndices) == CRank && sizeof...(AIndices) == ARank &&
                         std::is_arithmetic_v<U>> {
 
@@ -1003,7 +1003,7 @@ auto sort(const U UC_prefactor, const std::tuple<CIndices...> &C_indices, CType<
 
     // HPTT interface currently only works for full Tensors and not TensorViews
 #if defined(EINSUMS_USE_HPTT)
-    if constexpr (std::is_same_v<CType<CRank, T>, Tensor<CRank, T>> && std::is_same_v<AType<ARank, T>, Tensor<ARank, T>>) {
+    if constexpr (std::is_same_v<CType<T, CRank>, Tensor<T, CRank>> && std::is_same_v<AType<T, ARank>, Tensor<T, ARank>>) {
         std::array<int, ARank> perms{};
         std::array<int, ARank> size{};
 
@@ -1071,9 +1071,9 @@ auto sort(const std::tuple<CIndices...> &C_indices, SmartPointerC *C, const std:
 // Element Transform
 ///
 
-template <template <size_t, typename> typename CType, size_t CRank, typename UnaryOperator, typename T = double>
-auto element_transform(CType<CRank, T> *C, UnaryOperator unary_opt)
-    -> std::enable_if_t<std::is_base_of_v<::einsums::detail::TensorBase<CRank, T>, CType<CRank, T>>> {
+template <template <typename, size_t> typename CType, size_t CRank, typename UnaryOperator, typename T = double>
+auto element_transform(CType<T, CRank> *C, UnaryOperator unary_opt)
+    -> std::enable_if_t<std::is_base_of_v<::einsums::detail::TensorBase<T, CRank>, CType<T, CRank>>> {
     Section section(fmt::format("element transform: {}", C->name()));
     auto target_dims = get_dim_ranges<CRank>(*C);
     auto view = std::apply(ranges::views::cartesian_product, target_dims);
@@ -1093,9 +1093,9 @@ auto element_transform(SmartPtr *C, UnaryOperator unary_opt) -> std::enable_if_t
     element_transform(C->get(), unary_opt);
 }
 
-template <template <size_t, typename> typename CType, template <size_t, typename> typename... MultiTensors, size_t Rank,
+template <template <typename, size_t> typename CType, template <typename, size_t> typename... MultiTensors, size_t Rank,
           typename MultiOperator, typename T = double>
-auto element(MultiOperator multi_opt, CType<Rank, T> *C, MultiTensors<Rank, T>... tensors) {
+auto element(MultiOperator multi_opt, CType<T, Rank> *C, MultiTensors<T, Rank>... tensors) {
     Section section("element");
     auto target_dims = get_dim_ranges<Rank>(*C);
     auto view = std::apply(ranges::views::cartesian_product, target_dims);
@@ -1154,8 +1154,8 @@ constexpr auto get_n(const std::tuple<List...> &) {
  *
  * @returns unfolded_tensor of shape ``(tensor.dim(mode), -1)``
  */
-template <unsigned int mode, template <size_t, typename> typename CType, size_t CRank, typename T = double>
-auto unfold(const CType<CRank, T> &source) -> std::enable_if_t<std::is_same_v<Tensor<CRank, T>, CType<CRank, T>>, Tensor<2, T>> {
+template <unsigned int mode, template <typename, size_t> typename CType, size_t CRank, typename T = double>
+auto unfold(const CType<T, CRank> &source) -> std::enable_if_t<std::is_same_v<Tensor<T, CRank>, CType<T, CRank>>, Tensor<T, 2>> {
     Section section{fmt::format("mode-{} unfold on {} threads", mode, omp_get_max_threads())};
 
     Dim<2> target_dims;
@@ -1214,12 +1214,12 @@ auto unfold(const CType<CRank, T> &source) -> std::enable_if_t<std::is_same_v<Te
  *
  * Result is described as {(I,J), r}. If multiple common indices are provided they will be collapsed into a single index in the result.
  */
-template <template <size_t, typename> typename AType, size_t ARank, template <size_t, typename> typename BType, size_t BRank,
+template <template <typename, size_t> typename AType, size_t ARank, template <typename, size_t> typename BType, size_t BRank,
           typename... AIndices, typename... BIndices, typename T = double>
-auto khatri_rao(const std::tuple<AIndices...> &, const AType<ARank, T> &A, const std::tuple<BIndices...> &, const BType<BRank, T> &B)
-    -> std::enable_if_t<std::is_base_of_v<::einsums::detail::TensorBase<ARank, T>, AType<ARank, T>> &&
-                            std::is_base_of_v<::einsums::detail::TensorBase<BRank, T>, BType<BRank, T>>,
-                        Tensor<2, T>> {
+auto khatri_rao(const std::tuple<AIndices...> &, const AType<T, ARank> &A, const std::tuple<BIndices...> &, const BType<T, BRank> &B)
+    -> std::enable_if_t<std::is_base_of_v<::einsums::detail::TensorBase<T, ARank>, AType<T, ARank>> &&
+                            std::is_base_of_v<::einsums::detail::TensorBase<T, BRank>, BType<T, BRank>>,
+                        Tensor<T, 2>> {
 
     constexpr auto A_indices = std::tuple<AIndices...>();
     constexpr auto B_indices = std::tuple<BIndices...>();
@@ -1253,13 +1253,13 @@ auto khatri_rao(const std::tuple<AIndices...> &, const AType<ARank, T> &A, const
     auto result_dims = std::tuple_cat(std::make_tuple("KR product"), A_only_dims, B_only_dims, A_common_dims);
 
     // Construct resulting tensor
-    auto result = std::make_from_tuple<Tensor<std::tuple_size_v<decltype(result_dims)> - 1, T>>(result_dims);
+    auto result = std::make_from_tuple<Tensor<T, std::tuple_size_v<decltype(result_dims)> - 1>>(result_dims);
 
     // Perform the actual Khatri-Rao product using our einsum routine.
     einsum(std::tuple_cat(A_only, B_only, common), &result, std::tuple_cat(A_only, common), A, std::tuple_cat(B_only, common), B);
 
     // Return a reconstruction of the result tensor ... this can be considered as a simple reshape of the tensor.
-    return Tensor<2, T>{std::move(result), "KR product", -1, detail::product_dims(A_common_position, A)};
+    return Tensor<T, 2>{std::move(result), "KR product", -1, detail::product_dims(A_common_position, A)};
 }
 
 } // namespace einsums::tensor_algebra

--- a/tests/Decomposition.cpp
+++ b/tests/Decomposition.cpp
@@ -1,8 +1,8 @@
 #include "einsums/Decomposition.hpp"
 
+#include "einsums/LinearAlgebra.hpp"
 #include "einsums/Tensor.hpp"
 #include "einsums/TensorAlgebra.hpp"
-#include "einsums/LinearAlgebra.hpp"
 
 #include <catch2/catch.hpp>
 
@@ -11,17 +11,15 @@ TEST_CASE("CP 1") {
     using namespace einsums::tensor_algebra;
     using namespace einsums::decomposition;
 
-    Tensor<3, double> test1("test 1", 3, 3, 3);
-    test1.vector_data() = std::vector<double, einsums::AlignedAllocator<double, 64>>
-                            {0.94706517, 0.3959549, 0.14122476, 0.83665482, 0.27340639, 0.29811429,
-                             0.1823041, 0.66556282, 0.73178046, 0.72504222, 0.58360409, 0.68301135,
-                             0.8316929, 0.66955444, 0.25182224, 0.24108674, 0.09582611, 0.93056666,
-                             0.60919366, 0.97363788, 0.24531965, 0.23757898, 0.43426057, 0.64763913,
-                             0.61224901, 0.86068415, 0.12051599};
+    Tensor test1("test 1", 3, 3, 3);
+    test1.vector_data() = std::vector<double, einsums::AlignedAllocator<double, 64>>{
+        0.94706517, 0.3959549,  0.14122476, 0.83665482, 0.27340639, 0.29811429, 0.1823041,  0.66556282, 0.73178046,
+        0.72504222, 0.58360409, 0.68301135, 0.8316929,  0.66955444, 0.25182224, 0.24108674, 0.09582611, 0.93056666,
+        0.60919366, 0.97363788, 0.24531965, 0.23757898, 0.43426057, 0.64763913, 0.61224901, 0.86068415, 0.12051599};
 
     auto factors = parafac(test1, 2, 50, 1.0e-6);
 
-    Tensor<3, double> test1_cp = parafac_reconstruct<3, double>(factors);
+    Tensor test1_cp = parafac_reconstruct<3>(factors);
 
     double diff = rmsd(test1, test1_cp);
 
@@ -34,17 +32,16 @@ TEST_CASE("CP 2") {
     using namespace einsums::tensor_algebra;
     using namespace einsums::decomposition;
 
-    Tensor<3, double> test2("test 2", 3, 4, 2);
-    
-    test2.vector_data() = std::vector<double, einsums::AlignedAllocator<double, 64>>
-                            {0.29945093, 0.0090937, 0.99788559, 0.0821231, 0.29625705, 0.80278977,
-                             0.15189681, 0.35832086, 0.09648153, 0.39398175, 0.49662056, 0.83101396,
-                             0.84288292, 0.48603425, 0.93286471, 0.47101289, 0.32736096, 0.50067919,
-                             0.49932342, 0.91922942, 0.44777189, 0.23009644, 0.34874549, 0.19356636};
+    Tensor test2("test 2", 3, 4, 2);
+
+    test2.vector_data() = std::vector<double, einsums::AlignedAllocator<double, 64>>{
+        0.29945093, 0.0090937,  0.99788559, 0.0821231,  0.29625705, 0.80278977, 0.15189681, 0.35832086,
+        0.09648153, 0.39398175, 0.49662056, 0.83101396, 0.84288292, 0.48603425, 0.93286471, 0.47101289,
+        0.32736096, 0.50067919, 0.49932342, 0.91922942, 0.44777189, 0.23009644, 0.34874549, 0.19356636};
 
     auto factors = parafac(test2, 2, 50, 1.0e-6);
 
-    Tensor<3, double> test2_cp = parafac_reconstruct<3, double>(factors);
+    Tensor test2_cp = parafac_reconstruct<3>(factors);
 
     double diff = rmsd(test2, test2_cp);
 
@@ -57,19 +54,17 @@ TEST_CASE("CP 3") {
     using namespace einsums::tensor_algebra;
     using namespace einsums::decomposition;
 
-    Tensor<4, double> test3("test 3", 3, 2, 3, 2);
-    
-    test3.vector_data() = std::vector<double, einsums::AlignedAllocator<double, 64>>
-                            {0.37001224, 0.77676895, 0.17589323, 0.02762156, 0.21037116, 0.83686174,
-                             0.35042434, 0.19117270, 0.58095640, 0.99220655, 0.33536840, 0.15210615,
-                             0.95033534, 0.73212124, 0.31346639, 0.83961596, 0.15418801, 0.58927303,
-                             0.46744825, 0.44001279, 0.50372353, 0.09696069, 0.96449749, 0.71151666,
-                             0.72334792, 0.98646368, 0.13764230, 0.95949904, 0.07774470, 0.18239083,
-                             0.82591821, 0.40939436, 0.22088749, 0.90281597, 0.37465773, 0.02541923};
+    Tensor test3("test 3", 3, 2, 3, 2);
+
+    test3.vector_data() = std::vector<double, einsums::AlignedAllocator<double, 64>>{
+        0.37001224, 0.77676895, 0.17589323, 0.02762156, 0.21037116, 0.83686174, 0.35042434, 0.19117270, 0.58095640,
+        0.99220655, 0.33536840, 0.15210615, 0.95033534, 0.73212124, 0.31346639, 0.83961596, 0.15418801, 0.58927303,
+        0.46744825, 0.44001279, 0.50372353, 0.09696069, 0.96449749, 0.71151666, 0.72334792, 0.98646368, 0.13764230,
+        0.95949904, 0.07774470, 0.18239083, 0.82591821, 0.40939436, 0.22088749, 0.90281597, 0.37465773, 0.02541923};
 
     auto factors = parafac(test3, 2, 50, 1.0e-6);
 
-    Tensor<4, double> test3_cp = parafac_reconstruct<4, double>(factors);
+    Tensor test3_cp = parafac_reconstruct<4>(factors);
 
     double diff = rmsd(test3, test3_cp);
 
@@ -82,13 +77,11 @@ TEST_CASE("TUCKER 1") {
     using namespace einsums::tensor_algebra;
     using namespace einsums::decomposition;
 
-    Tensor<3, double> test1("test 1", 3, 3, 3);
-    test1.vector_data() = std::vector<double, einsums::AlignedAllocator<double, 64>>
-                            {0.94706517, 0.3959549, 0.14122476, 0.83665482, 0.27340639, 0.29811429,
-                             0.1823041, 0.66556282, 0.73178046, 0.72504222, 0.58360409, 0.68301135,
-                             0.8316929, 0.66955444, 0.25182224, 0.24108674, 0.09582611, 0.93056666,
-                             0.60919366, 0.97363788, 0.24531965, 0.23757898, 0.43426057, 0.64763913,
-                             0.61224901, 0.86068415, 0.12051599};
+    Tensor test1("test 1", 3, 3, 3);
+    test1.vector_data() = std::vector<double, einsums::AlignedAllocator<double, 64>>{
+        0.94706517, 0.3959549,  0.14122476, 0.83665482, 0.27340639, 0.29811429, 0.1823041,  0.66556282, 0.73178046,
+        0.72504222, 0.58360409, 0.68301135, 0.8316929,  0.66955444, 0.25182224, 0.24108674, 0.09582611, 0.93056666,
+        0.60919366, 0.97363788, 0.24531965, 0.23757898, 0.43426057, 0.64763913, 0.61224901, 0.86068415, 0.12051599};
 
     std::vector<size_t> ranks{2, 2, 2};
     auto result = tucker_ho_svd(test1, ranks);
@@ -119,12 +112,11 @@ TEST_CASE("TUCKER 2") {
     using namespace einsums::tensor_algebra;
     using namespace einsums::decomposition;
 
-    Tensor<3, double> test2("test 2", 3, 4, 2);
-    test2.vector_data() = std::vector<double, einsums::AlignedAllocator<double, 64>>
-                            {0.29945093, 0.0090937, 0.99788559, 0.0821231, 0.29625705, 0.80278977,
-                             0.15189681, 0.35832086, 0.09648153, 0.39398175, 0.49662056, 0.83101396,
-                             0.84288292, 0.48603425, 0.93286471, 0.47101289, 0.32736096, 0.50067919,
-                             0.49932342, 0.91922942, 0.44777189, 0.23009644, 0.34874549, 0.19356636};
+    Tensor test2("test 2", 3, 4, 2);
+    test2.vector_data() = std::vector<double, einsums::AlignedAllocator<double, 64>>{
+        0.29945093, 0.0090937,  0.99788559, 0.0821231,  0.29625705, 0.80278977, 0.15189681, 0.35832086,
+        0.09648153, 0.39398175, 0.49662056, 0.83101396, 0.84288292, 0.48603425, 0.93286471, 0.47101289,
+        0.32736096, 0.50067919, 0.49932342, 0.91922942, 0.44777189, 0.23009644, 0.34874549, 0.19356636};
 
     std::vector<size_t> ranks{2, 3, 2};
     auto result = tucker_ho_svd(test2, ranks);
@@ -155,15 +147,13 @@ TEST_CASE("TUCKER 3") {
     using namespace einsums::tensor_algebra;
     using namespace einsums::decomposition;
 
-    Tensor<4, double> test3("test 3", 3, 2, 3, 2);
+    Tensor test3("test 3", 3, 2, 3, 2);
 
-    test3.vector_data() = std::vector<double, einsums::AlignedAllocator<double, 64>>
-                            {0.37001224, 0.77676895, 0.17589323, 0.02762156, 0.21037116, 0.83686174,
-                             0.35042434, 0.19117270, 0.58095640, 0.99220655, 0.33536840, 0.15210615,
-                             0.95033534, 0.73212124, 0.31346639, 0.83961596, 0.15418801, 0.58927303,
-                             0.46744825, 0.44001279, 0.50372353, 0.09696069, 0.96449749, 0.71151666,
-                             0.72334792, 0.98646368, 0.13764230, 0.95949904, 0.07774470, 0.18239083,
-                             0.82591821, 0.40939436, 0.22088749, 0.90281597, 0.37465773, 0.02541923};
+    test3.vector_data() = std::vector<double, einsums::AlignedAllocator<double, 64>>{
+        0.37001224, 0.77676895, 0.17589323, 0.02762156, 0.21037116, 0.83686174, 0.35042434, 0.19117270, 0.58095640,
+        0.99220655, 0.33536840, 0.15210615, 0.95033534, 0.73212124, 0.31346639, 0.83961596, 0.15418801, 0.58927303,
+        0.46744825, 0.44001279, 0.50372353, 0.09696069, 0.96449749, 0.71151666, 0.72334792, 0.98646368, 0.13764230,
+        0.95949904, 0.07774470, 0.18239083, 0.82591821, 0.40939436, 0.22088749, 0.90281597, 0.37465773, 0.02541923};
 
     std::vector<size_t> ranks{2, 2, 2, 2};
     auto result = tucker_ho_svd(test3, ranks);

--- a/tests/Disk.cpp
+++ b/tests/Disk.cpp
@@ -16,9 +16,9 @@
 TEST_CASE("Creation", "[disktensor]") {
     using namespace einsums;
 
-    DiskTensor<2> A(state::data, "/A0", 3, 3);
-    DiskTensor<2> B(state::data, "/B0", 3, 3);
-    DiskTensor<2> C(state::data, "/C0", 3, 3);
+    DiskTensor A(state::data, "/A0", 3, 3);
+    DiskTensor B(state::data, "/B0", 3, 3);
+    DiskTensor C(state::data, "/C0", 3, 3);
 
     REQUIRE((A.dim(0) == 3 && A.dim(1) == 3));
     REQUIRE((B.dim(0) == 3 && B.dim(1) == 3));
@@ -147,20 +147,20 @@ TEST_CASE("DiskView 7x7x7x7", "[disktensor]") {
     using namespace einsums;
 
     SECTION("Write [7,7] data to [:,2,4,:]") {
-        DiskTensor<4> g(state::data, "g0", 7, 7, 7, 7);
-        Tensor<2> data = create_random_tensor("data", 7, 7);
+        DiskTensor g(state::data, "g0", 7, 7, 7, 7);
+        Tensor data = create_random_tensor("data", 7, 7);
         g(All{}, 2, 4, All{}) = data;
     }
 
     SECTION("Write [7,2,7] data to [:,4-5,2,:]") {
-        DiskTensor<4> g(state::data, "g1", 7, 7, 7, 7);
-        Tensor<3> data2 = create_random_tensor("data", 7, 2, 7);
+        DiskTensor g(state::data, "g1", 7, 7, 7, 7);
+        Tensor data2 = create_random_tensor("data", 7, 2, 7);
         g(All{}, Range{4, 6}, 2, All{}) = data2;
     }
 
     SECTION("Write/Read [7,7] data to/from [2,2,:,:]") {
-        DiskTensor<4> g(state::data, "g2", 3, 3, 3, 3);
-        Tensor<2> data3 = create_random_tensor("data", 3, 3);
+        DiskTensor g(state::data, "g2", 3, 3, 3, 3);
+        Tensor data3 = create_random_tensor("data", 3, 3);
         double value = 0.0;
 
         for (size_t i = 0; i < 3; i++) {

--- a/tests/Disk.cpp
+++ b/tests/Disk.cpp
@@ -36,25 +36,25 @@ TEST_CASE("Write/Read", "[disktensor]") {
     // println(Ad);
     A._write(Ad);
 
-    auto suba = A(0, All{});
+    auto suba = A(0, All);
     // println(suba);
     REQUIRE(suba(0) == Ad(0, 0));
     REQUIRE(suba(1) == Ad(0, 1));
     REQUIRE(suba(2) == Ad(0, 2));
 
-    auto subb = A(1, All{});
+    auto subb = A(1, All);
     // println(subb);
     REQUIRE(subb(0) == Ad(1, 0));
     REQUIRE(subb(1) == Ad(1, 1));
     REQUIRE(subb(2) == Ad(1, 2));
 
-    auto subc = A(All{}, 1);
+    auto subc = A(All, 1);
     // println(subc);
     REQUIRE(subc(0) == Ad(0, 1));
     REQUIRE(subc(1) == Ad(1, 1));
     REQUIRE(subc(2) == Ad(2, 1));
 
-    auto subd = A(Range{0, 2}, All{});
+    auto subd = A(Range{0, 2}, All);
     // println(subd);
     REQUIRE((subd.dim(0) == 2 && subd.dim(1) == 3));
     REQUIRE(subd(0, 0) == Ad(0, 0));
@@ -64,7 +64,7 @@ TEST_CASE("Write/Read", "[disktensor]") {
     REQUIRE(subd(1, 1) == Ad(1, 1));
     REQUIRE(subd(1, 2) == Ad(1, 2));
 
-    auto tempe = A(All{}, Range{1, 3});
+    auto tempe = A(All, Range{1, 3});
     auto &sube = tempe.get();
     REQUIRE((sube.dim(0) == 3 && sube.dim(1) == 2));
     REQUIRE(sube(0, 0) == Ad(0, 1));
@@ -87,7 +87,7 @@ TEST_CASE("DiskView 3x3", "[disktensor]") {
 
     {
         // Obtaining a DiskView does not automatically allocate memory.
-        auto suba = A(2, All{});
+        auto suba = A(2, All);
 
         Tensor<1> tempa{"tempa", 3};
         tempa(0) = 1.0;
@@ -149,13 +149,13 @@ TEST_CASE("DiskView 7x7x7x7", "[disktensor]") {
     SECTION("Write [7,7] data to [:,2,4,:]") {
         DiskTensor g(state::data, "g0", 7, 7, 7, 7);
         Tensor data = create_random_tensor("data", 7, 7);
-        g(All{}, 2, 4, All{}) = data;
+        g(All, 2, 4, All) = data;
     }
 
     SECTION("Write [7,2,7] data to [:,4-5,2,:]") {
         DiskTensor g(state::data, "g1", 7, 7, 7, 7);
         Tensor data2 = create_random_tensor("data", 7, 2, 7);
-        g(All{}, Range{4, 6}, 2, All{}) = data2;
+        g(All, Range{4, 6}, 2, All) = data2;
     }
 
     SECTION("Write/Read [7,7] data to/from [2,2,:,:]") {
@@ -173,7 +173,7 @@ TEST_CASE("DiskView 7x7x7x7", "[disktensor]") {
                     }
                 }
 
-                auto diskView = g(i, j, All{}, All{});
+                auto diskView = g(i, j, All, All);
                 auto &tensor = diskView.get();
 
                 tensor = data3;

--- a/tests/LinearAlgebra.cpp
+++ b/tests/LinearAlgebra.cpp
@@ -144,3 +144,60 @@ TEST_CASE("gemm") {
         gemm_test<std::complex<double>>();
     }
 }
+
+template <typename T>
+void syev_test() {
+    using namespace einsums;
+    using namespace einsums::linear_algebra;
+
+    auto A = create_tensor<T>("a", 3, 3);
+    auto b = create_tensor<T>("b", 3);
+
+    A.vector_data() = std::vector<T, einsums::AlignedAllocator<T, 64>>{1.0, 2.0, 3.0, 2.0, 4.0, 5.0, 3.0, 5.0, 6.0};
+
+    // Perform basic matrix multiplication
+    einsums::linear_algebra::syev(&A, &b);
+
+    CHECK_THAT(b(0), Catch::Matchers::WithinRel(-0.515729, 0.00001));
+    CHECK_THAT(b(1), Catch::Matchers::WithinRel(+0.170915, 0.00001));
+    CHECK_THAT(b(2), Catch::Matchers::WithinRel(+11.344814, 0.00001));
+}
+
+TEST_CASE("syev") {
+    SECTION("float") {
+        syev_test<float>();
+    }
+
+    SECTION("double") {
+        syev_test<double>();
+    }
+}
+
+template <typename T>
+void heev_test() {
+    using namespace einsums;
+    using namespace einsums::linear_algebra;
+
+    auto A = create_tensor<T>("a", 3, 3);
+    auto b = create_tensor<typename complex_type<T>::type>("b", 3);
+
+    A.vector_data() = std::vector<T, einsums::AlignedAllocator<T, 64>>{
+        {0.199889, 0.0},       {-0.330816, -0.127778},  {-0.0546237, 0.176589}, {-0.330816, 0.127778}, {0.629179, 0.0},
+        {-0.224813, 0.327171}, {-0.0546237, -0.176589}, {-0.0224813, 0.327171}, {0.170931, 0.0}};
+
+    println(A);
+
+    einsums::linear_algebra::heev(&A, &b);
+
+    println(A);
+    println(b);
+}
+
+TEST_CASE("heev") {
+    SECTION("float") {
+        heev_test<std::complex<float>>();
+    }
+    SECTION("double") {
+        heev_test<std::complex<double>>();
+    }
+}

--- a/tests/LinearAlgebra.cpp
+++ b/tests/LinearAlgebra.cpp
@@ -102,3 +102,14 @@ TEST_CASE("dgesv") {
                                            0.84222739, -0.10380185, 0.10571095, 0.95546491, 0.22065963, 1.90063673, 5.35766149, 4.04060266})
                    .margin(0.00001));
 }
+
+TEST_CASE("gemm") {
+    using namespace einsums;
+    using namespace einsums::linear_algebra;
+
+    SECTION("float") {
+        auto a = create_incremented_tensor<float>("a", 3, 3);
+        auto b = create_incremented_tensor<float>("b", 3, 3);
+        // auto c = Tensor
+    }
+}

--- a/tests/LinearAlgebra.cpp
+++ b/tests/LinearAlgebra.cpp
@@ -108,8 +108,12 @@ TEST_CASE("gemm") {
     using namespace einsums::linear_algebra;
 
     SECTION("float") {
-        auto a = create_incremented_tensor<float>("a", 3, 3);
-        auto b = create_incremented_tensor<float>("b", 3, 3);
-        // auto c = Tensor
+        auto A = create_incremented_tensor<float>("a", 3, 3);
+        auto B = create_incremented_tensor<float>("b", 3, 3);
+        auto C = create_incremented_tensor<float>("c", 3, 3);
+        zero(C);
+
+        // Perform basic matrix multiplication
+        einsums::linear_algebra::gemm<false, false>(1.0f, A, B, 0.0f, &C);
     }
 }

--- a/tests/LinearAlgebra.cpp
+++ b/tests/LinearAlgebra.cpp
@@ -6,7 +6,8 @@
 
 #include <catch2/catch.hpp>
 
-TEST_CASE("dgesv") {
+template <typename T>
+void gesv_test() {
     /*
    LAPACKE_dgesv Example.
    ======================
@@ -72,29 +73,41 @@ TEST_CASE("dgesv") {
 
     using namespace einsums;
 
-    Tensor a{"a", N, LDA};
-    Tensor b{"b", NRHS, LDB};
+    auto a = create_tensor<T>("a", N, LDA);
+    auto b = create_tensor<T>("b", NRHS, LDB);
 
-    a.vector_data() = std::vector<double, einsums::AlignedAllocator<double, 64>>{
-        6.80, -2.11, 5.66, 5.97, 8.23, -6.05, -3.30, 5.36,  -4.44, 1.08,  -0.45, 2.58, -2.70,
-        0.27, 9.04,  8.32, 2.71, 4.35, -7.17, 2.14,  -9.67, -5.14, -7.26, 6.08,  -6.87};
-    b.vector_data() = std::vector<double, einsums::AlignedAllocator<double, 64>>{4.02, 6.19, -8.22, -7.57, -3.03, -1.56, 4.00, -8.67,
-                                                                                 1.75, 2.86, 9.81,  -4.09, -4.57, -8.61, 8.99};
+    a.vector_data() = std::vector<T, einsums::AlignedAllocator<T, 64>>{6.80,  -2.11, 5.66,  5.97,  8.23,  -6.05, -3.30, 5.36, -4.44,
+                                                                       1.08,  -0.45, 2.58,  -2.70, 0.27,  9.04,  8.32,  2.71, 4.35,
+                                                                       -7.17, 2.14,  -9.67, -5.14, -7.26, 6.08,  -6.87};
+    b.vector_data() = std::vector<T, einsums::AlignedAllocator<T, 64>>{4.02, 6.19, -8.22, -7.57, -3.03, -1.56, 4.00, -8.67,
+                                                                       1.75, 2.86, 9.81,  -4.09, -4.57, -8.61, 8.99};
 
     linear_algebra::gesv(&a, &b);
 
     CHECK_THAT(a.vector_data(),
-               Catch::Matchers::Approx(std::vector<double, einsums::AlignedAllocator<double, 64>>{
+               Catch::Matchers::Approx(std::vector<T, einsums::AlignedAllocator<T, 64>>{
                                            8.23000000,  0.82624544,  0.68772783,  0.72539490, -0.25637910,  1.08000000,   -6.94234508,
                                            -0.66508563, 0.75240087,  0.43545957,  9.04000000, -7.91925881,  -14.18404477, 0.02320302,
                                            -0.58842060, 2.14000000,  6.55183475,  7.23579360, -13.81984350, -0.33743379,  -6.87000000,
                                            -3.99369380, -5.19145820, 14.18877913, -3.42921969})
                    .margin(0.00001));
     CHECK_THAT(b.vector_data(),
-               Catch::Matchers::Approx(std::vector<double, einsums::AlignedAllocator<double, 64>>{
+               Catch::Matchers::Approx(std::vector<T, einsums::AlignedAllocator<T, 64>>{
                                            -0.80071403, -0.69524338, 0.59391499, 1.32172561, 0.56575620, -0.38962139, -0.55442713,
                                            0.84222739, -0.10380185, 0.10571095, 0.95546491, 0.22065963, 1.90063673, 5.35766149, 4.04060266})
                    .margin(0.00001));
+}
+
+TEST_CASE("gesv") {
+    SECTION("float") {
+        gesv_test<float>();
+    }
+    SECTION("double") {
+        gesv_test<double>();
+    }
+    SECTION("complex<float>") {
+        // gesv_test<std::complex<float>>();
+    }
 }
 
 template <typename T>

--- a/tests/LinearAlgebra.cpp
+++ b/tests/LinearAlgebra.cpp
@@ -110,10 +110,40 @@ TEST_CASE("gemm") {
     SECTION("float") {
         auto A = create_incremented_tensor<float>("a", 3, 3);
         auto B = create_incremented_tensor<float>("b", 3, 3);
-        auto C = create_incremented_tensor<float>("c", 3, 3);
+        auto C = create_tensor<float>("c", 3, 3);
         zero(C);
 
         // Perform basic matrix multiplication
         einsums::linear_algebra::gemm<false, false>(1.0f, A, B, 0.0f, &C);
+
+        /// TODO: Actually test it.
+    }
+
+    SECTION("double") {
+        auto A = create_incremented_tensor<double>("a", 3, 3);
+        auto B = create_incremented_tensor<double>("b", 3, 3);
+        auto C = create_tensor<double>("c", 3, 3);
+        zero(C);
+
+        // Perform basic matrix multiplication
+        einsums::linear_algebra::gemm<false, false>(1.0, A, B, 0.0, &C);
+
+        /// TODO: Actually test it.
+    }
+
+    SECTION("complex float") {
+        auto A = create_incremented_tensor<std::complex<float>>("a", 3, 3);
+        auto B = create_incremented_tensor<std::complex<float>>("b", 3, 3);
+        auto C = create_tensor<std::complex<float>>("c", 3, 3);
+        zero(C);
+
+        // Perform basic matrix multiplication
+        einsums::linear_algebra::gemm<false, false>(std::complex<float>(1.0), A, B, std::complex<float>(0.0), &C);
+
+        /// TODO: Actually test it.
+        println(A);
+
+        auto D = create_random_tensor<std::complex<float>>("d", 3, 3);
+        println(D);
     }
 }

--- a/tests/LinearAlgebra.cpp
+++ b/tests/LinearAlgebra.cpp
@@ -185,12 +185,12 @@ void heev_test() {
         {0.199889, 0.0},       {-0.330816, -0.127778},  {-0.0546237, 0.176589}, {-0.330816, 0.127778}, {0.629179, 0.0},
         {-0.224813, 0.327171}, {-0.0546237, -0.176589}, {-0.0224813, 0.327171}, {0.170931, 0.0}};
 
-    println(A);
-
     einsums::linear_algebra::heev(&A, &b);
 
-    println(A);
-    println(b);
+    // Sometimes 0.0 will be reported as -0.0 therefore we test the Abs of the first two
+    CHECK_THAT(b(0), Catch::Matchers::WithinAbs(0.0, 0.00001));
+    CHECK_THAT(b(1), Catch::Matchers::WithinAbs(0.0, 0.00001));
+    CHECK_THAT(b(2), Catch::Matchers::WithinRel(1.0, 0.00001));
 }
 
 TEST_CASE("heev") {

--- a/tests/Tensor.cpp
+++ b/tests/Tensor.cpp
@@ -9,9 +9,11 @@
 #include <type_traits>
 
 TEST_CASE("Tensor creation", "[tensor]") {
-    einsums::Tensor A("A", 3, 3);
-    einsums::Tensor B("B", 3, 3);
-    einsums::Tensor C("C", 3, 3);
+    using namespace einsums;
+
+    Tensor A("A", 3, 3);
+    Tensor B("B", 3, 3);
+    auto C = create_tensor<double>("C", 3, 3);
 
     REQUIRE((A.dim(0) == 3 && A.dim(1) == 3));
     REQUIRE((B.dim(0) == 3 && B.dim(1) == 3));

--- a/tests/Tensor.cpp
+++ b/tests/Tensor.cpp
@@ -9,9 +9,9 @@
 #include <type_traits>
 
 TEST_CASE("Tensor creation", "[tensor]") {
-    einsums::Tensor<2, double> A("A", 3, 3);
-    einsums::Tensor<2, double> B("B", 3, 3);
-    einsums::Tensor<2, double> C("C", 3, 3);
+    einsums::Tensor A("A", 3, 3);
+    einsums::Tensor B("B", 3, 3);
+    einsums::Tensor C("C", 3, 3);
 
     REQUIRE((A.dim(0) == 3 && A.dim(1) == 3));
     REQUIRE((B.dim(0) == 3 && B.dim(1) == 3));
@@ -51,9 +51,9 @@ TEST_CASE("Tensor creation", "[tensor]") {
 }
 
 TEST_CASE("Tensor GEMMs", "[tensor]") {
-    einsums::Tensor<2, double> A("A", 3, 3);
-    einsums::Tensor<2, double> B("B", 3, 3);
-    einsums::Tensor<2, double> C("C", 3, 3);
+    einsums::Tensor A("A", 3, 3);
+    einsums::Tensor B("B", 3, 3);
+    einsums::Tensor C("C", 3, 3);
 
     REQUIRE((A.dim(0) == 3 && A.dim(1) == 3));
     REQUIRE((B.dim(0) == 3 && B.dim(1) == 3));
@@ -80,9 +80,9 @@ TEST_CASE("Tensor GEMMs", "[tensor]") {
 }
 
 TEST_CASE("Tensor GEMVs", "[tensor]") {
-    einsums::Tensor<2, double> A("A", 3, 3);
-    einsums::Tensor<1, double> x("x", 3);
-    einsums::Tensor<1, double> y("y", 3);
+    einsums::Tensor A("A", 3, 3);
+    einsums::Tensor x("x", 3);
+    einsums::Tensor y("y", 3);
 
     REQUIRE((A.dim(0) == 3 && A.dim(1) == 3));
     REQUIRE((x.dim(0) == 3));
@@ -99,8 +99,8 @@ TEST_CASE("Tensor GEMVs", "[tensor]") {
 }
 
 TEST_CASE("Tensor SYEVs", "[tensor]") {
-    einsums::Tensor<2, double> A("A", 3, 3);
-    einsums::Tensor<1, double> x("x", 3);
+    einsums::Tensor A("A", 3, 3);
+    einsums::Tensor x("x", 3);
 
     REQUIRE((A.dim(0) == 3 && A.dim(1) == 3));
     REQUIRE((x.dim(0) == 3));
@@ -115,7 +115,7 @@ TEST_CASE("Tensor SYEVs", "[tensor]") {
 }
 
 TEST_CASE("Tensor Invert") {
-    einsums::Tensor<2, double> A("A", 3, 3);
+    einsums::Tensor A("A", 3, 3);
     A(0, 0) = 1.0;
     A(0, 1) = 2.0;
     A(0, 2) = 3.0;
@@ -140,7 +140,7 @@ TEST_CASE("TensorView creation", "[tensor]") {
     einsums::TensorView viewA(A, einsums::Dim<2>{3, 9});
 
     // Since we are changing the underlying datatype to float the deduction guides will not work.
-    einsums::Tensor<3, float> fA("A", 3, 3, 3);
+    einsums::Tensor fA("A", 3, 3, 3);
     einsums::TensorView fviewA(fA, einsums::Dim<2>{3, 9});
 
     for (int i = 0, ijk = 0; i < 3; i++)
@@ -157,7 +157,7 @@ TEST_CASE("TensorView creation", "[tensor]") {
 }
 
 TEST_CASE("Tensor-2D HDF5") {
-    einsums::Tensor<2, double> A("A", 3, 3);
+    einsums::Tensor A("A", 3, 3);
 
     for (int i = 0, ij = 0; i < 3; i++) {
         for (int j = 0; j < 3; j++, ij++) {
@@ -172,7 +172,7 @@ TEST_CASE("Tensor-2D HDF5") {
     }
 
     {
-        auto B = h5::read<einsums::Tensor<2, double>>("tensor.h5", "Matrix A");
+        auto B = h5::read<einsums::Tensor<double, 2>>("tensor.h5", "Matrix A");
 
         REQUIRE((B.dim(0) == 10 && B.dim(1) == 20));
         REQUIRE(B(2, 2) == 0.0);
@@ -194,7 +194,7 @@ TEST_CASE("Tensor-1D HDF5") {
     }
 
     {
-        auto B = h5::read<einsums::Tensor<1, double>>("tensor-1d.h5", "A");
+        auto B = h5::read<einsums::Tensor<double, 1>>("tensor-1d.h5", "A");
 
         REQUIRE(A(0) == B(0));
         REQUIRE(A(1) == B(1));
@@ -212,7 +212,7 @@ TEST_CASE("Tensor-3D HDF5") {
     }
 
     {
-        auto B = h5::read<einsums::Tensor<3, double>>("tensor-3d.h5", "A");
+        auto B = h5::read<einsums::Tensor<double, 3>>("tensor-3d.h5", "A");
 
         REQUIRE(B.dim(0) == 3);
         REQUIRE(B.dim(1) == 2);
@@ -223,7 +223,7 @@ TEST_CASE("Tensor-3D HDF5") {
 TEST_CASE("TensorView-2D HDF5") {
     SECTION("Subview Offset{0,0,0}") {
         auto A = einsums::create_random_tensor("A", 3, 3, 3);
-        einsums::TensorView<2, double> viewA(A, einsums::Dim<2>{3, 9});
+        einsums::TensorView<double, 2> viewA(A, einsums::Dim<2>{3, 9});
 
         REQUIRE((A.dim(0) == 3 && A.dim(1) == 3 && A.dim(2) == 3));
         REQUIRE((viewA.dim(0) == 3 && viewA.dim(1) == 9));
@@ -235,7 +235,7 @@ TEST_CASE("TensorView-2D HDF5") {
         }
 
         {
-            auto B = h5::read<einsums::Tensor<2, double>>("tensorview-2d.h5", "A");
+            auto B = h5::read<einsums::Tensor<double, 2>>("tensorview-2d.h5", "A");
             for (int i = 0; i < 3; i++)
                 for (int j = 0; j < 9; j++)
                     REQUIRE(viewA(i, j) == B(i, j));
@@ -248,7 +248,7 @@ TEST_CASE("TensorView Ranges") {
 
     SECTION("Subviews") {
         auto C = einsums::create_random_tensor("C", 3, 3);
-        einsums::TensorView<2> viewC(C, einsums::Dim<2>{2, 2}, einsums::Offset<2>{1, 1}, einsums::Stride<2>{3, 1});
+        einsums::TensorView viewC(C, einsums::Dim<2>{2, 2}, einsums::Offset<2>{1, 1}, einsums::Stride<2>{3, 1});
 
         // einsums::println("C strides: %zu %zu\n", C.strides()[0], C.strides()[1]);
 
@@ -261,7 +261,7 @@ TEST_CASE("TensorView Ranges") {
     SECTION("Subviews 2") {
         auto C = einsums::create_random_tensor("C", 3, 3);
         // std::array<einsums::Range, 2> test;
-        einsums::TensorView<2> viewC = C(einsums::Range{1, 3}, einsums::Range{1, 3});
+        einsums::TensorView viewC = C(einsums::Range{1, 3}, einsums::Range{1, 3});
 
         // einsums::println(C);
         // einsums::println(viewC);

--- a/tests/TensorAlgebra.cpp
+++ b/tests/TensorAlgebra.cpp
@@ -825,7 +825,7 @@ TEST_CASE("einsum2") {
         Tensor<2> B = create_random_tensor("B", 5, 3);
 
         REQUIRE_NOTHROW(einsum(Indices{i, j}, &C0, Indices{i, k}, A, Indices{k, j}, B));
-        linear_algebra::gemm<false, false>(1.0, A, B, 0, &C1);
+        linear_algebra::gemm<false, false>(1.0, A, B, 0.0, &C1);
 
         for (size_t i0 = 0; i0 < C0.dim(0); i0++) {
             for (size_t j0 = 0; j0 < C0.dim(1); j0++) {
@@ -841,7 +841,7 @@ TEST_CASE("einsum2") {
         Tensor<2> B = create_random_tensor("B", 3, 5);
 
         REQUIRE_NOTHROW(einsum(Indices{i, j}, &C0, Indices{i, k}, A, Indices{j, k}, B));
-        linear_algebra::gemm<false, true>(1.0, A, B, 0, &C1);
+        linear_algebra::gemm<false, true>(1.0, A, B, 0.0, &C1);
 
         for (size_t i0 = 0; i0 < C0.dim(0); i0++) {
             for (size_t j0 = 0; j0 < C0.dim(1); j0++) {
@@ -979,7 +979,7 @@ TEST_CASE("einsum3") {
 
         // Working to get the einsum to perform the gemm that follows.
         REQUIRE_NOTHROW(einsum(Indices{i, j}, &C0, Indices{i, k}, A, Indices{k, j}, B));
-        linear_algebra::gemm<false, false>(1.0, A, B, 0, &C1);
+        linear_algebra::gemm<false, false>(1.0, A, B, 0.0, &C1);
 
         for (size_t i0 = 0; i0 < C0.dim(0); i0++) {
             for (size_t j0 = 0; j0 < C0.dim(1); j0++) {
@@ -1434,7 +1434,7 @@ TEST_CASE("unique_ptr") {
 
         // Working to get the einsum to perform the gemm that follows.
         REQUIRE_NOTHROW(einsum(Indices{i, j}, &C0, Indices{i, k}, A, Indices{k, j}, B));
-        linear_algebra::gemm<false, false>(1.0, A, B, 0, &C1);
+        linear_algebra::gemm<false, false>(1.0, A, B, 0.0, &C1);
 
         for (size_t i0 = 0; i0 < C0->dim(0); i0++) {
             for (size_t j0 = 0; j0 < C0->dim(1); j0++) {
@@ -1451,7 +1451,7 @@ TEST_CASE("unique_ptr") {
 
         // Working to get the einsum to perform the gemm that follows.
         REQUIRE_NOTHROW(einsum(Indices{i, j}, &C0, Indices{i, k}, A, Indices{k, j}, B));
-        linear_algebra::gemm<false, false>(1.0, *A, B, 0, &C1);
+        linear_algebra::gemm<false, false>(1.0, *A, B, 0.0, &C1);
 
         for (size_t i0 = 0; i0 < C0.dim(0); i0++) {
             for (size_t j0 = 0; j0 < C0.dim(1); j0++) {
@@ -1468,7 +1468,7 @@ TEST_CASE("unique_ptr") {
 
         // Working to get the einsum to perform the gemm that follows.
         REQUIRE_NOTHROW(einsum(Indices{i, j}, &C0, Indices{i, k}, A, Indices{k, j}, B));
-        linear_algebra::gemm<false, false>(1.0, A, *B, 0, &C1);
+        linear_algebra::gemm<false, false>(1.0, A, *B, 0.0, &C1);
 
         for (size_t i0 = 0; i0 < C0.dim(0); i0++) {
             for (size_t j0 = 0; j0 < C0.dim(1); j0++) {
@@ -1485,7 +1485,7 @@ TEST_CASE("unique_ptr") {
 
         // Working to get the einsum to perform the gemm that follows.
         REQUIRE_NOTHROW(einsum(Indices{i, j}, &C0, Indices{i, k}, A, Indices{k, j}, B));
-        linear_algebra::gemm<false, false>(1.0, *A, *B, 0, &C1);
+        linear_algebra::gemm<false, false>(1.0, *A, *B, 0.0, &C1);
 
         for (size_t i0 = 0; i0 < C0.dim(0); i0++) {
             for (size_t j0 = 0; j0 < C0.dim(1); j0++) {
@@ -1502,7 +1502,7 @@ TEST_CASE("unique_ptr") {
 
         // Working to get the einsum to perform the gemm that follows.
         REQUIRE_NOTHROW(einsum(Indices{i, j}, &C0, Indices{i, k}, A, Indices{k, j}, B));
-        linear_algebra::gemm<false, false>(1.0, *A, B, 0, &C1);
+        linear_algebra::gemm<false, false>(1.0, *A, B, 0.0, &C1);
 
         for (size_t i0 = 0; i0 < C0->dim(0); i0++) {
             for (size_t j0 = 0; j0 < C0->dim(1); j0++) {
@@ -1519,7 +1519,7 @@ TEST_CASE("unique_ptr") {
 
         // Working to get the einsum to perform the gemm that follows.
         REQUIRE_NOTHROW(einsum(Indices{i, j}, &C0, Indices{i, k}, A, Indices{k, j}, B));
-        linear_algebra::gemm<false, false>(1.0, A, *B, 0, &C1);
+        linear_algebra::gemm<false, false>(1.0, A, *B, 0.0, &C1);
 
         for (size_t i0 = 0; i0 < C0->dim(0); i0++) {
             for (size_t j0 = 0; j0 < C0->dim(1); j0++) {
@@ -1536,7 +1536,7 @@ TEST_CASE("unique_ptr") {
 
         // Working to get the einsum to perform the gemm that follows.
         REQUIRE_NOTHROW(einsum(Indices{i, j}, &C0, Indices{i, k}, A, Indices{k, j}, B));
-        linear_algebra::gemm<false, false>(1.0, *A, *B, 0, &C1);
+        linear_algebra::gemm<false, false>(1.0, *A, *B, 0.0, &C1);
 
         for (size_t i0 = 0; i0 < C0->dim(0); i0++) {
             for (size_t j0 = 0; j0 < C0->dim(1); j0++) {

--- a/tests/TensorAlgebra.cpp
+++ b/tests/TensorAlgebra.cpp
@@ -193,7 +193,7 @@ TEST_CASE("Subset TensorView", "[tensor]") {
         const size_t row = 1;
 
         Tensor I_original = create_random_tensor("Original", size, size);
-        TensorView I_view = I_original(row, All{});
+        TensorView I_view = I_original(row, All);
 
         for (size_t i = 0; i < size; i++) {
             REQUIRE(I_original(row, i) == I_view(i));
@@ -205,7 +205,7 @@ TEST_CASE("Subset TensorView", "[tensor]") {
         const size_t d1 = 4;
 
         Tensor I_original = create_random_tensor("Original", size, size, size);
-        TensorView I_view = I_original(d1, All{}, All{});
+        TensorView I_view = I_original(d1, All, All);
 
         for (size_t i = 0; i < size; i++) {
             for (size_t j = 0; j < size; j++) {
@@ -220,7 +220,7 @@ TEST_CASE("Subset TensorView", "[tensor]") {
         const size_t d2 = 3;
 
         Tensor I_original = create_random_tensor("Original", size, size, size);
-        TensorView I_view = I_original(d1, d2, All{});
+        TensorView I_view = I_original(d1, d2, All);
 
         for (size_t i = 0; i < size; i++) {
             REQUIRE(I_original(d1, d2, i) == I_view(i));
@@ -241,7 +241,7 @@ TEST_CASE("Subset TensorView", "[tensor]") {
         }
 
         // Obtain a 3x3 view of original[4,:,:]
-        TensorView view = original(d1, All{}, All{});
+        TensorView view = original(d1, All, All);
         Tensor result{"result", d2_size, d3_size};
 
         // false, false
@@ -327,10 +327,10 @@ TEST_CASE("Subset TensorView", "[tensor]") {
 
         // Obtain a 3x3 view of original[4,:,:]
         //   A view does not copy data it is just an offset pointer into the original with necessary striding information.
-        TensorView view = original(d1, All{}, All{});
+        TensorView view = original(d1, All, All);
 
         // Obtain a 3x3 view of original[2,:,:] to store the result
-        TensorView result = original(e1, All{}, All{});
+        TensorView result = original(e1, All, All);
 
         // false, false
         {
@@ -528,10 +528,10 @@ TEST_CASE("einsum TensorView", "[tensor]") {
         Tensor copy = original;
 
         // Obtain a 3x3 view of original[4,:,:]
-        TensorView view = original(d1, All{}, All{});
+        TensorView view = original(d1, All, All);
 
         // Obtain a 3x3 view of original[2,:,:] to store the result
-        TensorView result = original(e1, All{}, All{});
+        TensorView result = original(e1, All, All);
 
         // false, false
         {
@@ -1048,8 +1048,8 @@ TEST_CASE("einsum3") {
 
         for (size_t i0 = 0; i0 < gMO0.dim(0); i0++) {
             for (size_t j0 = 0; j0 < gMO0.dim(1); j0++) {
-                auto vgMO0 = gMO0(i0, j0, All{}, All{});
-                REQUIRE_NOTHROW(einsum(Indices{k, l}, &vgMO0, Indices{p, l}, A(i0, j0, All{}, All{}), Indices{p, k}, B));
+                auto vgMO0 = gMO0(i0, j0, All, All);
+                REQUIRE_NOTHROW(einsum(Indices{k, l}, &vgMO0, Indices{p, l}, A(i0, j0, All, All), Indices{p, k}, B));
             }
         }
 
@@ -1135,8 +1135,8 @@ TEST_CASE("einsum4") {
 #if 0
         for (size_t i0 = 0; i0 < gMO0.dim(0); i0++) {
             for (size_t j0 = 0; j0 < gMO0.dim(1); j0++) {
-                auto vgMO0 = gMO0(i0, j0, All{}, All{});
-                TensorAlgebra::einsum(Indices{k, s}, &vgMO0, Indices{r, s}, A(i0, j0, All{}, All{}), Indices{r, k}, B);
+                auto vgMO0 = gMO0(i0, j0, All, All);
+                TensorAlgebra::einsum(Indices{k, s}, &vgMO0, Indices{r, s}, A(i0, j0, All, All), Indices{r, k}, B);
             }
         }
 
@@ -1201,8 +1201,8 @@ TEST_CASE("IntegralTransformation") {
     //     write(State::data, C3);
     //     write(State::data, C4);
 
-    //     disk_ao(All{}, All{}, All{}, All{}) = memory_ao;
-    //     auto temp = disk_ao(All{}, All{}, All{}, All{});
+    //     disk_ao(All, All, All, All) = memory_ao;
+    //     auto temp = disk_ao(All, All, All, All);
     //     auto &temp2 = temp.get();
 
     //     // Ensure the data was saved to disk correctly
@@ -1232,7 +1232,7 @@ TEST_CASE("IntegralTransformation") {
 
     //     for (size_t i0 = 0; i0 < C1.dim(1); i0++) {
     //         for (size_t j0 = 0; j0 < C2.dim(1); j0++) {
-    //             auto disk_view = disk_result(i0, j0, All{}, All{});
+    //             auto disk_view = disk_result(i0, j0, All, All);
     //             auto &disk_tensor = disk_view.get();
     //             for (size_t k0 = 0; k0 < C3.dim(1); k0++) {
     //                 for (size_t l0 = 0; l0 < C4.dim(1); l0++) {
@@ -2111,8 +2111,8 @@ TEST_CASE("einsum element") {
         Tensor parentC0 = parentC;
         Tensor parentA = create_random_tensor("parentA", _i, _i, _i, _j);
 
-        auto C = parentC(3, All{}, All{}, 4);
-        auto C0 = parentC0(3, All{}, All{}, 4);
+        auto C = parentC(3, All, All, 4);
+        auto C0 = parentC0(3, All, All, 4);
         Tensor testresult{"result", _i, _j};
 
         for (int w = 0; w < _i; w++) {
@@ -2121,7 +2121,7 @@ TEST_CASE("einsum element") {
             }
         }
 
-        auto A = parentA(1, 2, All{}, All{});
+        auto A = parentA(1, 2, All, All);
 
         element([](double const &Cval, double const &Aval) -> double { return Cval * Aval; }, &C, A);
 
@@ -2234,7 +2234,7 @@ TEST_CASE("B_tilde") {
     zero(CD0);
     auto C = create_random_tensor("C", nocc, nocc, nvir, nvir);
     auto D = create_random_tensor("D", nocc, nocc, nvir, nvir);
-    auto D_ij = D(2, 2, All{}, All{});
+    auto D_ij = D(2, 2, All, All);
 
     einsum(Indices{k, l, a, b}, &CD, Indices{k, l, a, b}, C, Indices{a, b}, D_ij);
 

--- a/tests/TensorAlgebra.cpp
+++ b/tests/TensorAlgebra.cpp
@@ -1,11 +1,13 @@
 #include "einsums/TensorAlgebra.hpp"
 
 #include "einsums/LinearAlgebra.hpp"
+#include "einsums/STL.hpp"
 #include "einsums/State.hpp"
 #include "einsums/Tensor.hpp"
 
 #include <H5Fpublic.h>
 #include <catch2/catch.hpp>
+#include <complex>
 #include <type_traits>
 
 TEST_CASE("Identity Tensor", "[tensor]") {
@@ -2317,5 +2319,60 @@ TEST_CASE("Khatri-Rao") {
                 REQUIRE_THAT(KR(x, z), Catch::Matchers::WithinAbs(KR0_view(x, z), 0.000001));
             }
         }
+    }
+}
+
+template <typename TC, typename TA, typename TB>
+void einsum_mixed_test() {
+    using namespace einsums;
+    using namespace einsums::tensor_algebra;
+    using namespace einsums::tensor_algebra::index;
+
+    const auto i_ = 10, j_ = 10, k_ = 10;
+
+    auto A = create_random_tensor<TA>("A", i_, k_);
+    auto B = create_random_tensor<TB>("B", k_, j_);
+    auto C = create_tensor<TC>("C", i_, j_);
+    auto C0 = create_tensor<TC>("C0", i_, j_);
+    zero(C);
+    zero(C0);
+
+    einsum(Indices{i, j}, &C, Indices{i, k}, A, Indices{k, j}, B);
+
+    for (size_t i = 0; i < i_; i++) {
+        for (size_t j = 0; j < j_; j++) {
+            for (size_t k = 0; k < k_; k++) {
+                C0(i, j) += A(i, k) * B(k, j);
+            }
+        }
+    }
+
+    for (size_t i = 0; i < i_; i++) {
+        for (size_t j = 0; j < j_; j++) {
+            // println("{:20.14f} {:20.14f} {:20.14f}", C(i, j), C0(i, j), std::abs(C(i, j) - C0(i, j)));
+            CHECK(std::abs(C(i, j) - C0(i, j)) < complex_type_t<TC>{1.0E-5});
+            // REQUIRE_THAT(C(i, j), Catch::Matchers::WithinAbs(C0(i, j), complex_type_t<TC>{1.0E-16}));
+        }
+    }
+}
+
+TEST_CASE("einsum-mixed") {
+    SECTION("d-f-d") {
+        einsum_mixed_test<double, float, double>();
+    }
+    SECTION("d-f-f") {
+        einsum_mixed_test<double, float, float>();
+    }
+    SECTION("f-d-d") {
+        einsum_mixed_test<float, double, double>();
+    }
+    SECTION("cd-cd-d") {
+        einsum_mixed_test<std::complex<double>, std::complex<double>, double>();
+    }
+    SECTION("d-d-d") {
+        einsum_mixed_test<double, double, double>();
+    }
+    SECTION("cf-cd-f") {
+        einsum_mixed_test<std::complex<float>, std::complex<float>, std::complex<float>>();
     }
 }

--- a/tests/TensorAlgebra.cpp
+++ b/tests/TensorAlgebra.cpp
@@ -12,7 +12,7 @@ TEST_CASE("Identity Tensor", "[tensor]") {
     using namespace einsums;
     using namespace einsums::tensor_algebra;
 
-    Tensor<2, double> I = create_identity_tensor("I", 3, 3);
+    Tensor I = create_identity_tensor("I", 3, 3);
 
     REQUIRE(I(0, 0) == 1.0);
     REQUIRE(I(0, 1) == 0.0);
@@ -29,8 +29,8 @@ TEST_CASE("Scale Row", "[tensor]") {
     using namespace einsums;
     using namespace einsums::linear_algebra;
 
-    Tensor<2> I_original = create_random_tensor("I", 3, 3);
-    Tensor<2> I_copy = I_original;
+    Tensor I_original = create_random_tensor("I", 3, 3);
+    Tensor I_copy = I_original;
 
     scale_row(1, 2.0, &I_copy);
 
@@ -49,8 +49,8 @@ TEST_CASE("Scale Column", "[tensor]") {
     using namespace einsums;
     using namespace einsums::linear_algebra;
 
-    Tensor<2> I_original = create_random_tensor("I", 3, 3);
-    Tensor<2> I_copy = I_original;
+    Tensor I_original = create_random_tensor("I", 3, 3);
+    Tensor I_copy = I_original;
 
     scale_column(1, 2.0, &I_copy);
 
@@ -69,9 +69,9 @@ TEST_CASE("Scale Row TensorView", "[tensor]") {
     using namespace einsums;
     using namespace einsums::linear_algebra;
 
-    Tensor<2> I_original = create_random_tensor("I", 3, 3);
-    Tensor<2> I_copy = I_original;
-    TensorView<2> I_view{I_copy, Dim<2>{2, 2}, Offset<2>{1, 1}};
+    Tensor I_original = create_random_tensor("I", 3, 3);
+    Tensor I_copy = I_original;
+    TensorView I_view{I_copy, Dim<2>{2, 2}, Offset<2>{1, 1}};
 
     scale_row(1, 2.0, &I_view);
 
@@ -95,9 +95,9 @@ TEST_CASE("Scale Column TensorView", "[tensor]") {
     using namespace einsums;
     using namespace einsums::linear_algebra;
 
-    Tensor<2> I_original = create_random_tensor("I", 3, 3);
-    Tensor<2> I_copy = I_original;
-    TensorView<2> I_view{I_copy, Dim<2>{2, 2}, Offset<2>{1, 1}};
+    Tensor I_original = create_random_tensor("I", 3, 3);
+    Tensor I_copy = I_original;
+    TensorView I_view{I_copy, Dim<2>{2, 2}, Offset<2>{1, 1}};
 
     scale_column(1, 2.0, &I_view);
 
@@ -121,17 +121,17 @@ TEST_CASE("GEMM TensorView", "[tensor]") {
     using namespace einsums;
     using namespace einsums::linear_algebra;
 
-    Tensor<2> I_original{"I", 3, 3};
+    Tensor I_original{"I", 3, 3};
 
     for (int i = 0, ij = 1; i < 3; i++)
         for (int j = 0; j < 3; j++, ij++)
             I_original(i, j) = ij;
 
-    Tensor<2> I_copy = I_original;
-    TensorView<2> I_view{I_copy, Dim<2>{2, 2}, Offset<2>{1, 1}};
+    Tensor I_copy = I_original;
+    TensorView I_view{I_copy, Dim<2>{2, 2}, Offset<2>{1, 1}};
 
     SECTION("Result into 2x2 matrix") {
-        Tensor<2> result{"result", 2, 2};
+        Tensor result{"result", 2, 2};
 
         gemm<false, false>(1.0, I_view, I_view, 0.0, &result);
 
@@ -142,9 +142,9 @@ TEST_CASE("GEMM TensorView", "[tensor]") {
     }
 
     SECTION("Result into 2x2 view of matrix") {
-        Tensor<2> result{"result", 5, 5};
+        Tensor result{"result", 5, 5};
         result.zero();
-        TensorView<2> result_view{result, Dim<2>{2, 2}, Offset<2>{3, 2}};
+        TensorView result_view{result, Dim<2>{2, 2}, Offset<2>{3, 2}};
 
         gemm<false, false>(1.0, I_view, I_view, 0.0, &result_view);
 
@@ -162,7 +162,7 @@ TEST_CASE("GEMM TensorView", "[tensor]") {
     }
 
     SECTION("Transpose") {
-        Tensor<2> result{"result", 2, 2};
+        Tensor result{"result", 2, 2};
 
         gemm<false, true>(1.0, I_view, I_view, 0.0, &result);
         REQUIRE(result(0, 0) == 61.0);
@@ -192,8 +192,8 @@ TEST_CASE("Subset TensorView", "[tensor]") {
         const size_t size = 7;
         const size_t row = 1;
 
-        Tensor<2> I_original = create_random_tensor("Original", size, size);
-        TensorView<1> I_view = I_original(row, All{});
+        Tensor I_original = create_random_tensor("Original", size, size);
+        TensorView I_view = I_original(row, All{});
 
         for (size_t i = 0; i < size; i++) {
             REQUIRE(I_original(row, i) == I_view(i));
@@ -204,8 +204,8 @@ TEST_CASE("Subset TensorView", "[tensor]") {
         const size_t size = 7;
         const size_t d1 = 4;
 
-        Tensor<3> I_original = create_random_tensor("Original", size, size, size);
-        TensorView<2> I_view = I_original(d1, All{}, All{});
+        Tensor I_original = create_random_tensor("Original", size, size, size);
+        TensorView I_view = I_original(d1, All{}, All{});
 
         for (size_t i = 0; i < size; i++) {
             for (size_t j = 0; j < size; j++) {
@@ -219,8 +219,8 @@ TEST_CASE("Subset TensorView", "[tensor]") {
         const size_t d1 = 4;
         const size_t d2 = 3;
 
-        Tensor<3> I_original = create_random_tensor("Original", size, size, size);
-        TensorView<1> I_view = I_original(d1, d2, All{});
+        Tensor I_original = create_random_tensor("Original", size, size, size);
+        TensorView I_view = I_original(d1, d2, All{});
 
         for (size_t i = 0; i < size; i++) {
             REQUIRE(I_original(d1, d2, i) == I_view(i));
@@ -231,7 +231,7 @@ TEST_CASE("Subset TensorView", "[tensor]") {
         const size_t d1_size = 7, d2_size = 3, d3_size = 3;
         const size_t d1 = 4;
 
-        Tensor<3> original = create_random_tensor("Original", d1_size, d2_size, d3_size);
+        Tensor original = create_random_tensor("Original", d1_size, d2_size, d3_size);
 
         // Set submatrix to a set of known values
         for (size_t i = 0, ij = 1; i < 3; i++) {
@@ -241,8 +241,8 @@ TEST_CASE("Subset TensorView", "[tensor]") {
         }
 
         // Obtain a 3x3 view of original[4,:,:]
-        TensorView<2> view = original(d1, All{}, All{});
-        Tensor<2> result{"result", d2_size, d3_size};
+        TensorView view = original(d1, All{}, All{});
+        Tensor result{"result", d2_size, d3_size};
 
         // false, false
         {
@@ -314,7 +314,7 @@ TEST_CASE("Subset TensorView", "[tensor]") {
         const size_t e1 = 2;
         const std::array<size_t, 6> untouched_d1{0, 1, 3, 4, 5, 6};
 
-        Tensor<3> original = create_random_tensor("Original", d1_size, d2_size, d3_size);
+        Tensor original = create_random_tensor("Original", d1_size, d2_size, d3_size);
 
         // Set submatrix to a set of known values
         for (size_t i = 0, ij = 1; i < 3; i++) {
@@ -323,14 +323,14 @@ TEST_CASE("Subset TensorView", "[tensor]") {
             }
         }
 
-        Tensor<3> copy = original;
+        Tensor copy = original;
 
         // Obtain a 3x3 view of original[4,:,:]
         //   A view does not copy data it is just an offset pointer into the original with necessary striding information.
-        TensorView<2> view = original(d1, All{}, All{});
+        TensorView view = original(d1, All{}, All{});
 
         // Obtain a 3x3 view of original[2,:,:] to store the result
-        TensorView<2> result = original(e1, All{}, All{});
+        TensorView result = original(e1, All{}, All{});
 
         // false, false
         {
@@ -434,9 +434,9 @@ TEST_CASE("einsum1", "[tensor]") {
     using namespace einsums::tensor_algebra;
 
     SECTION("ik=ij,jk") {
-        Tensor<2> A{"A", 3, 3};
-        Tensor<2> B{"B", 3, 3};
-        Tensor<2> C{"C", 3, 3};
+        Tensor A{"A", 3, 3};
+        Tensor B{"B", 3, 3};
+        Tensor C{"C", 3, 3};
 
         for (int i = 0, ij = 1; i < 3; i++) {
             for (int j = 0; j < 3; j++, ij++) {
@@ -466,9 +466,9 @@ TEST_CASE("einsum1", "[tensor]") {
     }
 
     SECTION("il=ijk,jkl") {
-        Tensor<3> A{"A", 3, 3, 3};
-        Tensor<3> B{"B", 3, 3, 3};
-        Tensor<2> C{"C", 3, 3};
+        Tensor A{"A", 3, 3, 3};
+        Tensor B{"B", 3, 3, 3};
+        Tensor C{"C", 3, 3};
 
         for (int i = 0, ij = 1; i < 3; i++) {
             for (int j = 0; j < 3; j++) {
@@ -516,7 +516,7 @@ TEST_CASE("einsum TensorView", "[tensor]") {
         const size_t e1 = 2;
         const std::array<size_t, 6> untouched1{0, 1, 3, 4, 5, 6};
 
-        Tensor<3> original = create_random_tensor("Original", d1_size, d2_size, d3_size);
+        Tensor original = create_random_tensor("Original", d1_size, d2_size, d3_size);
 
         // Set submatrix to a set of known values
         for (size_t i = 0, ij = 1; i < 3; i++) {
@@ -525,13 +525,13 @@ TEST_CASE("einsum TensorView", "[tensor]") {
             }
         }
 
-        Tensor<3> copy = original;
+        Tensor copy = original;
 
         // Obtain a 3x3 view of original[4,:,:]
-        TensorView<2> view = original(d1, All{}, All{});
+        TensorView view = original(d1, All{}, All{});
 
         // Obtain a 3x3 view of original[2,:,:] to store the result
-        TensorView<2> result = original(e1, All{}, All{});
+        TensorView result = original(e1, All{}, All{});
 
         // false, false
         {
@@ -580,8 +580,8 @@ TEST_CASE("sort2") {
     using namespace einsums::tensor_algebra::index;
 
     SECTION("Rank 2 - axpy") {
-        Tensor<2> A{"A", 3, 3};
-        Tensor<2> C{"C", 3, 3};
+        Tensor A{"A", 3, 3};
+        Tensor C{"C", 3, 3};
 
         for (int i = 0, ij = 1; i < 3; i++) {
             for (int j = 0; j < 3; j++, ij++) {
@@ -597,8 +597,8 @@ TEST_CASE("sort2") {
             }
         }
 
-        TensorView<2> A_view{A, Dim<2>{2, 2}, Offset<2>{1, 1}};
-        TensorView<2> C_view{C, Dim<2>{2, 2}, Offset<2>{1, 1}};
+        TensorView A_view{A, Dim<2>{2, 2}, Offset<2>{1, 1}};
+        TensorView C_view{C, Dim<2>{2, 2}, Offset<2>{1, 1}};
 
         sort(Indices{j, i}, &C_view, Indices{i, j}, A_view);
 
@@ -613,9 +613,9 @@ TEST_CASE("sort2") {
     }
 
     SECTION("Rank 2 - axpy (2)") {
-        Tensor<2> A = create_random_tensor("A", 3, 3);
-        Tensor<2> C0{"C", 3, 3};
-        Tensor<2> C1{"C", 3, 3};
+        Tensor A = create_random_tensor("A", 3, 3);
+        Tensor C0{"C", 3, 3};
+        Tensor C1{"C", 3, 3};
 
         for (int i = 0, ij = 1; i < 3; i++) {
             for (int j = 0; j < 3; j++, ij++) {
@@ -649,8 +649,8 @@ TEST_CASE("sort2") {
     }
 
     SECTION("Rank 2") {
-        Tensor<2> A{"A", 3, 3};
-        Tensor<2> C{"C", 3, 3};
+        Tensor A{"A", 3, 3};
+        Tensor C{"C", 3, 3};
 
         for (int i = 0, ij = 1; i < 3; i++) {
             for (int j = 0; j < 3; j++, ij++) {
@@ -668,8 +668,8 @@ TEST_CASE("sort2") {
     }
 
     SECTION("Rank 3") {
-        Tensor<3> A{"A", 3, 3, 3};
-        Tensor<3> B{"B", 3, 3, 3};
+        Tensor A{"A", 3, 3, 3};
+        Tensor B{"B", 3, 3, 3};
 
         for (int i = 0, ij = 1; i < 3; i++) {
             for (int j = 0; j < 3; j++) {
@@ -717,8 +717,8 @@ TEST_CASE("sort2") {
     }
 
     SECTION("Rank 4") {
-        Tensor<4> A{"A", 3, 3, 3, 3};
-        Tensor<4> B{"B", 3, 3, 3, 3};
+        Tensor A{"A", 3, 3, 3, 3};
+        Tensor B{"B", 3, 3, 3, 3};
 
         for (int i = 0, ij = 1; i < 3; i++) {
             for (int j = 0; j < 3; j++) {
@@ -743,8 +743,8 @@ TEST_CASE("sort2") {
     }
 
     SECTION("Rank 5") {
-        Tensor<5, float> A{"A", 3, 3, 3, 3, 3};
-        Tensor<5, float> B{"B", 3, 3, 3, 3, 3};
+        Tensor<float, 5> A{"A", 3, 3, 3, 3, 3};
+        Tensor<float, 5> B{"B", 3, 3, 3, 3, 3};
 
         for (short i = 0, ij = 1; i < 3; i++) {
             for (int j = 0; j < 3; j++) {
@@ -773,8 +773,8 @@ TEST_CASE("sort2") {
     }
 
     SECTION("Rank 2 - Different Sizes") {
-        Tensor<2> A{"A", 3, 9};
-        Tensor<2> B{"B", 9, 3};
+        Tensor A{"A", 3, 9};
+        Tensor B{"B", 9, 3};
 
         for (int i = 0, ij = 0; i < A.dim(0); i++) {
             for (int j = 0; j < A.dim(1); j++, ij++) {
@@ -791,8 +791,8 @@ TEST_CASE("sort2") {
     }
 
     SECTION("Rank 3 - Different Sizes") {
-        Tensor<3> A{"A", 2, 3, 4};
-        Tensor<3> B{"B", 3, 4, 2};
+        Tensor A{"A", 2, 3, 4};
+        Tensor B{"B", 3, 4, 2};
 
         for (int i = 0, ij = 1; i < A.dim(0); i++) {
             for (int j = 0; j < A.dim(1); j++) {
@@ -819,10 +819,10 @@ TEST_CASE("einsum2") {
     using namespace einsums::tensor_algebra::index;
 
     SECTION("3x3 <- 3x5 * 5x3") {
-        Tensor<2> C0{"C0", 3, 3};
-        Tensor<2> C1{"C1", 3, 3};
-        Tensor<2> A = create_random_tensor("A", 3, 5);
-        Tensor<2> B = create_random_tensor("B", 5, 3);
+        Tensor C0{"C0", 3, 3};
+        Tensor C1{"C1", 3, 3};
+        Tensor A = create_random_tensor("A", 3, 5);
+        Tensor B = create_random_tensor("B", 5, 3);
 
         REQUIRE_NOTHROW(einsum(Indices{i, j}, &C0, Indices{i, k}, A, Indices{k, j}, B));
         linear_algebra::gemm<false, false>(1.0, A, B, 0.0, &C1);
@@ -835,10 +835,10 @@ TEST_CASE("einsum2") {
     }
 
     SECTION("3x3 <- 3x5 * 3x5") {
-        Tensor<2> C0{"C0", 3, 3};
-        Tensor<2> C1{"C1", 3, 3};
-        Tensor<2> A = create_random_tensor("A", 3, 5);
-        Tensor<2> B = create_random_tensor("B", 3, 5);
+        Tensor C0{"C0", 3, 3};
+        Tensor C1{"C1", 3, 3};
+        Tensor A = create_random_tensor("A", 3, 5);
+        Tensor B = create_random_tensor("B", 3, 5);
 
         REQUIRE_NOTHROW(einsum(Indices{i, j}, &C0, Indices{i, k}, A, Indices{j, k}, B));
         linear_algebra::gemm<false, true>(1.0, A, B, 0.0, &C1);
@@ -851,10 +851,10 @@ TEST_CASE("einsum2") {
     }
 
     SECTION("3 <- 3x5 * 5") {
-        Tensor<1> C0{"C0", 3};
-        Tensor<1> C1{"C1", 3};
-        Tensor<2> A = create_random_tensor("A", 3, 5);
-        Tensor<1> B = create_random_tensor("B", 5);
+        Tensor C0{"C0", 3};
+        Tensor C1{"C1", 3};
+        Tensor A = create_random_tensor("A", 3, 5);
+        Tensor B = create_random_tensor("B", 5);
 
         C0.zero();
         C1.zero();
@@ -868,12 +868,12 @@ TEST_CASE("einsum2") {
     }
 
     SECTION("3 <- 3x4x5 * 4x3x5") {
-        Tensor<1> C0{"C0", 3};
+        Tensor C0{"C0", 3};
         zero(C0);
-        Tensor<1> C1{"C1", 3};
+        Tensor C1{"C1", 3};
         zero(C1);
-        Tensor<3> A = create_random_tensor("A", 3, 4, 5);
-        Tensor<3> B = create_random_tensor("B", 4, 3, 5);
+        Tensor A = create_random_tensor("A", 3, 4, 5);
+        Tensor B = create_random_tensor("B", 4, 3, 5);
 
         REQUIRE_NOTHROW(einsum(Indices{i}, &C0, Indices{i, j, k}, A, Indices{j, i, k}, B));
 
@@ -894,12 +894,12 @@ TEST_CASE("einsum2") {
     }
 
     SECTION("3x5 <- 3x4x5 * 4x3x5") {
-        Tensor<2> C0{"C0", 3, 5};
-        Tensor<2> C1{"C1", 3, 5};
+        Tensor C0{"C0", 3, 5};
+        Tensor C1{"C1", 3, 5};
         zero(C0);
         zero(C1);
-        Tensor<3> A = create_random_tensor("A", 3, 4, 5);
-        Tensor<3> B = create_random_tensor("B", 4, 3, 5);
+        Tensor A = create_random_tensor("A", 3, 4, 5);
+        Tensor B = create_random_tensor("B", 4, 3, 5);
 
         // timer::push("einsum: 3x5 <- 3x4x5 * 4x3x5");
         REQUIRE_NOTHROW(einsum(Indices{i, k}, &C0, Indices{i, j, k}, A, Indices{j, i, k}, B));
@@ -926,12 +926,12 @@ TEST_CASE("einsum2") {
     }
 
     SECTION("3, l <- 3x4x5 * 4x3x5") {
-        Tensor<2> C0{"C0", 3, 5};
+        Tensor C0{"C0", 3, 5};
         zero(C0);
-        Tensor<2> C1{"C1", 3, 5};
+        Tensor C1{"C1", 3, 5};
         zero(C1);
-        Tensor<3> A = create_random_tensor("A", 3, 4, 5);
-        Tensor<3> B = create_random_tensor("B", 4, 3, 5);
+        Tensor A = create_random_tensor("A", 3, 4, 5);
+        Tensor B = create_random_tensor("B", 4, 3, 5);
 
         // timer::push("einsum: 3x5 <- 3x4x5 * 4x3x5");
         REQUIRE_NOTHROW(einsum(Indices{i, l}, &C0, Indices{i, j, k}, A, Indices{j, i, k}, B));
@@ -972,10 +972,10 @@ TEST_CASE("einsum3") {
     // timer::initialize();
 
     SECTION("3x3 <- 3x5 * 5x3") {
-        Tensor<2> C0{"C0", 3, 3};
-        Tensor<2> C1{"C1", 3, 3};
-        Tensor<2> A = create_random_tensor("A", 3, 5);
-        Tensor<2> B = create_random_tensor("B", 5, 3);
+        Tensor C0{"C0", 3, 3};
+        Tensor C1{"C1", 3, 3};
+        Tensor A = create_random_tensor("A", 3, 5);
+        Tensor B = create_random_tensor("B", 5, 3);
 
         // Working to get the einsum to perform the gemm that follows.
         REQUIRE_NOTHROW(einsum(Indices{i, j}, &C0, Indices{i, k}, A, Indices{k, j}, B));
@@ -990,12 +990,12 @@ TEST_CASE("einsum3") {
 
     SECTION("3x3x3x3 <- 3x3x3x3 * 3x3") {
         // This one is to represent a two-electron integral transformation
-        Tensor<4> gMO0{"g0", 3, 3, 3, 3};
-        Tensor<4> gMO1{"g1", 3, 3, 3, 3};
+        Tensor gMO0{"g0", 3, 3, 3, 3};
+        Tensor gMO1{"g1", 3, 3, 3, 3};
         zero(gMO0);
         zero(gMO1);
-        Tensor<4> A = create_random_tensor("A", 3, 3, 3, 3);
-        Tensor<2> B = create_random_tensor("B", 3, 3);
+        Tensor A = create_random_tensor("A", 3, 3, 3, 3);
+        Tensor B = create_random_tensor("B", 3, 3);
 
         REQUIRE_NOTHROW(einsum(Indices{i, j, k, l}, &gMO0, Indices{i, j, k, p}, A, Indices{p, l}, B));
 
@@ -1076,12 +1076,12 @@ TEST_CASE("einsum4") {
     // timer::initialize();
     SECTION("3x3x3x3 <- 3x3x3x3 * 3x3") {
         // This one is to represent a two-electron integral transformation
-        Tensor<4> gMO0{"g0", 3, 3, 3, 3};
-        Tensor<4> gMO1{"g1", 3, 3, 3, 3};
+        Tensor gMO0{"g0", 3, 3, 3, 3};
+        Tensor gMO1{"g1", 3, 3, 3, 3};
         zero(gMO0);
         zero(gMO1);
-        Tensor<4> A = create_random_tensor("A", 3, 3, 3, 3);
-        Tensor<2> B = create_random_tensor("B", 3, 3);
+        Tensor A = create_random_tensor("A", 3, 3, 3, 3);
+        Tensor B = create_random_tensor("B", 3, 3);
 
         REQUIRE_NOTHROW(einsum(Indices{p, q, r, l}, &gMO0, Indices{p, q, r, s}, A, Indices{s, l}, B));
 
@@ -1165,14 +1165,14 @@ TEST_CASE("IntegralTransformation") {
 
     // timer::initialize();
     // SECTION("3x3x3x3 <- 3x3x3x3 * 3x3 * 3x3 * 3x3 * 3x3") {
-    //     Tensor<2> C1 = create_random_tensor("C1", 4, 2);
-    //     Tensor<2> C2 = create_random_tensor("C2", 4, 2);
-    //     Tensor<2> C3 = create_random_tensor("C3", 4, 3);
-    //     Tensor<2> C4 = create_random_tensor("C4", 4, 4);
+    //     Tensor C1 = create_random_tensor("C1", 4, 2);
+    //     Tensor C2 = create_random_tensor("C2", 4, 2);
+    //     Tensor C3 = create_random_tensor("C3", 4, 3);
+    //     Tensor C4 = create_random_tensor("C4", 4, 4);
 
-    //     Tensor<4> true_answer{"true", 2, 2, 3, 4};
-    //     Tensor<4> memory_ao = create_random_tensor("ao", 4, 4, 4, 4);
-    //     DiskTensor<4> disk_ao{State::data, "ao", 4, 4, 4, 4};
+    //     Tensor true_answer{"true", 2, 2, 3, 4};
+    //     Tensor memory_ao = create_random_tensor("ao", 4, 4, 4, 4);
+    //     DiskTensor disk_ao{State::data, "ao", 4, 4, 4, 4};
 
     //     // #pragma omp parallel for collapse(8)
     //     for (size_t i0 = 0; i0 < C1.dim(1); i0++) {
@@ -1244,9 +1244,9 @@ TEST_CASE("IntegralTransformation") {
     // }
 
     SECTION("R2 <- R3 * R3") {
-        Tensor<2> W_mi = create_random_tensor("W_mi", 4, 4);
-        Tensor<3> g_m = create_random_tensor("g_m", 4, 8, 8);
-        Tensor<3> t_i = create_random_tensor("t_i", 4, 8, 8);
+        Tensor W_mi = create_random_tensor("W_mi", 4, 4);
+        Tensor g_m = create_random_tensor("g_m", 4, 8, 8);
+        Tensor t_i = create_random_tensor("t_i", 4, 8, 8);
 
         // println(W_mi);
         // println(g_m);
@@ -1265,10 +1265,10 @@ TEST_CASE("Hadamard") {
     size_t _i = 3, _j = 4, _k = 5;
 
     SECTION("i,j <- i,i * j*j") {
-        Tensor<2> A = create_random_tensor("A", _i, _i);
-        Tensor<2> B = create_random_tensor("B", _j, _j);
-        Tensor<2> C{"C", _i, _j};
-        Tensor<2> C0{"C0", _i, _j};
+        Tensor A = create_random_tensor("A", _i, _i);
+        Tensor B = create_random_tensor("B", _j, _j);
+        Tensor C{"C", _i, _j};
+        Tensor C0{"C0", _i, _j};
         C0.zero();
         C.zero();
 
@@ -1294,10 +1294,10 @@ TEST_CASE("Hadamard") {
     }
 
     SECTION("i,j <- i,i,j * j,j,i") {
-        Tensor<3> A = create_random_tensor("A", _i, _i, _j);
-        Tensor<3> B = create_random_tensor("B", _j, _j, _i);
-        Tensor<2> C{"C", _i, _j};
-        Tensor<2> C0{"C0", _i, _j};
+        Tensor A = create_random_tensor("A", _i, _i, _j);
+        Tensor B = create_random_tensor("B", _j, _j, _i);
+        Tensor C{"C", _i, _j};
+        Tensor C0{"C0", _i, _j};
         C0.zero();
         C.zero();
 
@@ -1323,10 +1323,10 @@ TEST_CASE("Hadamard") {
     }
 
     SECTION("i,j <- i,j,i * j,i,j") {
-        Tensor<3> A = create_random_tensor("A", _i, _j, _i);
-        Tensor<3> B = create_random_tensor("B", _j, _i, _j);
-        Tensor<2> C{"C", _i, _j};
-        Tensor<2> C0{"C0", _i, _j};
+        Tensor A = create_random_tensor("A", _i, _j, _i);
+        Tensor B = create_random_tensor("B", _j, _i, _j);
+        Tensor C{"C", _i, _j};
+        Tensor C0{"C0", _i, _j};
         C0.zero();
         C.zero();
 
@@ -1352,10 +1352,10 @@ TEST_CASE("Hadamard") {
     }
 
     SECTION("i,j,i <- i,j,i * j,i,j") {
-        Tensor<3> A = create_random_tensor("A", _i, _j, _i);
-        Tensor<3> B = create_random_tensor("B", _j, _i, _j);
-        Tensor<3> C{"C", _i, _j, _i};
-        Tensor<3> C0{"C0", _i, _j, _i};
+        Tensor A = create_random_tensor("A", _i, _j, _i);
+        Tensor B = create_random_tensor("B", _j, _i, _j);
+        Tensor C{"C", _i, _j, _i};
+        Tensor C0{"C0", _i, _j, _i};
         C0.zero();
         C.zero();
 
@@ -1375,10 +1375,10 @@ TEST_CASE("Hadamard") {
     }
 
     SECTION("i,i,i <- i,j,i * j,i,j") {
-        Tensor<3> A = create_random_tensor("A", _i, _j, _i);
-        Tensor<3> B = create_random_tensor("B", _j, _i, _j);
-        Tensor<3> C{"C", _i, _i, _i};
-        Tensor<3> C0{"C0", _i, _i, _i};
+        Tensor A = create_random_tensor("A", _i, _j, _i);
+        Tensor B = create_random_tensor("B", _j, _i, _j);
+        Tensor C{"C", _i, _i, _i};
+        Tensor C0{"C0", _i, _i, _i};
         C0.zero();
         C.zero();
 
@@ -1396,10 +1396,10 @@ TEST_CASE("Hadamard") {
     }
 
     SECTION("i,i <- i,j,k * j,i,k") {
-        Tensor<3> A = create_random_tensor("A", _i, _j, _k);
-        Tensor<3> B = create_random_tensor("B", _j, _i, _k);
-        Tensor<2> C{"C", _i, _i};
-        Tensor<2> C0{"C0", _i, _i};
+        Tensor A = create_random_tensor("A", _i, _j, _k);
+        Tensor B = create_random_tensor("B", _j, _i, _k);
+        Tensor C{"C", _i, _i};
+        Tensor C0{"C0", _i, _i};
         C0.zero();
         C.zero();
 
@@ -1427,10 +1427,10 @@ TEST_CASE("unique_ptr") {
     using namespace einsums::tensor_algebra::index;
 
     SECTION("C") {
-        auto C0 = std::make_unique<Tensor<2>>("C0", 3, 3);
-        Tensor<2> C1{"C1", 3, 3};
-        Tensor<2> A = create_random_tensor("A", 3, 5);
-        Tensor<2> B = create_random_tensor("B", 5, 3);
+        auto C0 = std::make_unique<Tensor<double, 2>>("C0", 3, 3);
+        Tensor C1{"C1", 3, 3};
+        Tensor A = create_random_tensor("A", 3, 5);
+        Tensor B = create_random_tensor("B", 5, 3);
 
         // Working to get the einsum to perform the gemm that follows.
         REQUIRE_NOTHROW(einsum(Indices{i, j}, &C0, Indices{i, k}, A, Indices{k, j}, B));
@@ -1444,10 +1444,10 @@ TEST_CASE("unique_ptr") {
     }
 
     SECTION("A") {
-        Tensor<2> C0{"C0", 3, 3};
-        Tensor<2> C1{"C1", 3, 3};
-        auto A = std::make_unique<Tensor<2>>(create_random_tensor("A", 3, 5));
-        Tensor<2> B = create_random_tensor("B", 5, 3);
+        Tensor C0{"C0", 3, 3};
+        Tensor C1{"C1", 3, 3};
+        auto A = std::make_unique<Tensor<double, 2>>(create_random_tensor("A", 3, 5));
+        Tensor B = create_random_tensor("B", 5, 3);
 
         // Working to get the einsum to perform the gemm that follows.
         REQUIRE_NOTHROW(einsum(Indices{i, j}, &C0, Indices{i, k}, A, Indices{k, j}, B));
@@ -1461,10 +1461,10 @@ TEST_CASE("unique_ptr") {
     }
 
     SECTION("B") {
-        Tensor<2> C0{"C0", 3, 3};
-        Tensor<2> C1{"C1", 3, 3};
-        Tensor<2> A = create_random_tensor("A", 3, 5);
-        auto B = std::make_unique<Tensor<2>>(create_random_tensor("B", 5, 3));
+        Tensor C0{"C0", 3, 3};
+        Tensor C1{"C1", 3, 3};
+        Tensor A = create_random_tensor("A", 3, 5);
+        auto B = std::make_unique<Tensor<double, 2>>(create_random_tensor("B", 5, 3));
 
         // Working to get the einsum to perform the gemm that follows.
         REQUIRE_NOTHROW(einsum(Indices{i, j}, &C0, Indices{i, k}, A, Indices{k, j}, B));
@@ -1478,10 +1478,10 @@ TEST_CASE("unique_ptr") {
     }
 
     SECTION("AB") {
-        Tensor<2> C0{"C0", 3, 3};
-        Tensor<2> C1{"C1", 3, 3};
-        auto A = std::make_unique<Tensor<2>>(create_random_tensor("A", 3, 5));
-        auto B = std::make_unique<Tensor<2>>(create_random_tensor("B", 5, 3));
+        Tensor C0{"C0", 3, 3};
+        Tensor C1{"C1", 3, 3};
+        auto A = std::make_unique<Tensor<double, 2>>(create_random_tensor("A", 3, 5));
+        auto B = std::make_unique<Tensor<double, 2>>(create_random_tensor("B", 5, 3));
 
         // Working to get the einsum to perform the gemm that follows.
         REQUIRE_NOTHROW(einsum(Indices{i, j}, &C0, Indices{i, k}, A, Indices{k, j}, B));
@@ -1495,10 +1495,10 @@ TEST_CASE("unique_ptr") {
     }
 
     SECTION("CA") {
-        auto C0 = std::make_unique<Tensor<2>>("C0", 3, 3);
-        Tensor<2> C1{"C1", 3, 3};
-        auto A = std::make_unique<Tensor<2>>(create_random_tensor("A", 3, 5));
-        Tensor<2> B = create_random_tensor("B", 5, 3);
+        auto C0 = std::make_unique<Tensor<double, 2>>("C0", 3, 3);
+        Tensor C1{"C1", 3, 3};
+        auto A = std::make_unique<Tensor<double, 2>>(create_random_tensor("A", 3, 5));
+        Tensor B = create_random_tensor("B", 5, 3);
 
         // Working to get the einsum to perform the gemm that follows.
         REQUIRE_NOTHROW(einsum(Indices{i, j}, &C0, Indices{i, k}, A, Indices{k, j}, B));
@@ -1512,10 +1512,10 @@ TEST_CASE("unique_ptr") {
     }
 
     SECTION("CB") {
-        auto C0 = std::make_unique<Tensor<2>>("C0", 3, 3);
-        Tensor<2> C1{"C1", 3, 3};
-        Tensor<2> A = create_random_tensor("A", 3, 5);
-        auto B = std::make_unique<Tensor<2>>(create_random_tensor("B", 5, 3));
+        auto C0 = std::make_unique<Tensor<double, 2>>("C0", 3, 3);
+        Tensor C1{"C1", 3, 3};
+        Tensor A = create_random_tensor("A", 3, 5);
+        auto B = std::make_unique<Tensor<double, 2>>(create_random_tensor("B", 5, 3));
 
         // Working to get the einsum to perform the gemm that follows.
         REQUIRE_NOTHROW(einsum(Indices{i, j}, &C0, Indices{i, k}, A, Indices{k, j}, B));
@@ -1529,10 +1529,10 @@ TEST_CASE("unique_ptr") {
     }
 
     SECTION("CAB") {
-        auto C0 = std::make_unique<Tensor<2>>("C0", 3, 3);
-        Tensor<2> C1{"C1", 3, 3};
-        auto A = std::make_unique<Tensor<2>>(create_random_tensor("A", 3, 5));
-        auto B = std::make_unique<Tensor<2>>(create_random_tensor("B", 5, 3));
+        auto C0 = std::make_unique<Tensor<double, 2>>("C0", 3, 3);
+        Tensor C1{"C1", 3, 3};
+        auto A = std::make_unique<Tensor<double, 2>>(create_random_tensor("A", 3, 5));
+        auto B = std::make_unique<Tensor<double, 2>>(create_random_tensor("B", 5, 3));
 
         // Working to get the einsum to perform the gemm that follows.
         REQUIRE_NOTHROW(einsum(Indices{i, j}, &C0, Indices{i, k}, A, Indices{k, j}, B));
@@ -1554,10 +1554,10 @@ TEST_CASE("Transpose C", "[einsum]") {
     size_t _i = 3, _j = 4, _k = 5;
 
     SECTION("i,j <- j,k * k,i === true, false, false") {
-        Tensor<2> A = create_random_tensor("A", _j, _k);
-        Tensor<2> B = create_random_tensor("B", _k, _i);
-        Tensor<2> C{"C", _i, _j};
-        Tensor<2> C0{"C0", _i, _j};
+        Tensor A = create_random_tensor("A", _j, _k);
+        Tensor B = create_random_tensor("B", _k, _i);
+        Tensor C{"C", _i, _j};
+        Tensor C0{"C0", _i, _j};
         C0.zero();
 
         REQUIRE_NOTHROW(einsum(Indices{i, j}, &C, Indices{j, k}, A, Indices{k, i}, B));
@@ -1581,10 +1581,10 @@ TEST_CASE("Transpose C", "[einsum]") {
     }
 
     SECTION("i,j <- k,j * k,i === true, true, false") {
-        Tensor<2> A = create_random_tensor("A", _k, _j);
-        Tensor<2> B = create_random_tensor("B", _k, _i);
-        Tensor<2> C{"C", _i, _j};
-        Tensor<2> C0{"C0", _i, _j};
+        Tensor A = create_random_tensor("A", _k, _j);
+        Tensor B = create_random_tensor("B", _k, _i);
+        Tensor C{"C", _i, _j};
+        Tensor C0{"C0", _i, _j};
         C0.zero();
 
         REQUIRE_NOTHROW(einsum(Indices{i, j}, &C, Indices{k, j}, A, Indices{k, i}, B));
@@ -1608,10 +1608,10 @@ TEST_CASE("Transpose C", "[einsum]") {
     }
 
     SECTION("i,j <- j,k * i,k === true, false, true") {
-        Tensor<2> A = create_random_tensor("A", _j, _k);
-        Tensor<2> B = create_random_tensor("B", _i, _k);
-        Tensor<2> C{"C", _i, _j};
-        Tensor<2> C0{"C0", _i, _j};
+        Tensor A = create_random_tensor("A", _j, _k);
+        Tensor B = create_random_tensor("B", _i, _k);
+        Tensor C{"C", _i, _j};
+        Tensor C0{"C0", _i, _j};
         C0.zero();
 
         REQUIRE_NOTHROW(einsum(Indices{i, j}, &C, Indices{j, k}, A, Indices{i, k}, B));
@@ -1635,10 +1635,10 @@ TEST_CASE("Transpose C", "[einsum]") {
     }
 
     SECTION("i,j <- k,j * i,k === true, true, true") {
-        Tensor<2> A = create_random_tensor("A", _k, _j);
-        Tensor<2> B = create_random_tensor("B", _i, _k);
-        Tensor<2> C{"C", _i, _j};
-        Tensor<2> C0{"C0", _i, _j};
+        Tensor A = create_random_tensor("A", _k, _j);
+        Tensor B = create_random_tensor("B", _i, _k);
+        Tensor C{"C", _i, _j};
+        Tensor C0{"C0", _i, _j};
         C0.zero();
 
         REQUIRE_NOTHROW(einsum(Indices{i, j}, &C, Indices{k, j}, A, Indices{i, k}, B));
@@ -1664,13 +1664,13 @@ TEST_CASE("Transpose C", "[einsum]") {
     SECTION("Wmnij <- 0.25 t_ijef * g_mnef") {
         size_t _m = 12, _n = 12, _i = 5, _j = 5, _e = 7, _f = 7;
 
-        Tensor<4> Wmnij{"Wmnij", _m, _n, _i, _j};
+        Tensor Wmnij{"Wmnij", _m, _n, _i, _j};
         zero(Wmnij);
-        Tensor<4> W0{"Wmnij", _m, _n, _i, _j};
+        Tensor W0{"Wmnij", _m, _n, _i, _j};
         zero(W0);
 
-        Tensor<4> t_oovv = create_random_tensor("t_oovv", _i, _j, _e, _f);
-        Tensor<4> g_oovv = create_random_tensor("g_oovv", _m, _n, _e, _f);
+        Tensor t_oovv = create_random_tensor("t_oovv", _i, _j, _e, _f);
+        Tensor g_oovv = create_random_tensor("g_oovv", _m, _n, _e, _f);
 
         REQUIRE_NOTHROW(einsum(1.0, Indices{m, n, i, j}, &Wmnij, 0.25, Indices{i, j, e, f}, t_oovv, Indices{m, n, e, f}, g_oovv));
 
@@ -1708,17 +1708,17 @@ TEST_CASE("gemv") {
     SECTION("check") {
         size_t _p = 7, _q = 7, _r = 7, _s = 7;
 
-        Tensor<4> g = create_random_tensor("g", _p, _q, _r, _s);
-        Tensor<2> D = create_random_tensor("d", _r, _s);
+        Tensor g = create_random_tensor("g", _p, _q, _r, _s);
+        Tensor D = create_random_tensor("d", _r, _s);
 
-        Tensor<2> F{"F", _p, _q};
-        Tensor<2> F0{"F0", _p, _q};
+        Tensor F{"F", _p, _q};
+        Tensor F0{"F0", _p, _q};
 
         REQUIRE_NOTHROW(einsum(1.0, Indices{p, q}, &F0, 2.0, Indices{p, q, r, s}, g, Indices{r, s}, D));
 
-        TensorView<2> gv{g, Dim<2>{_p * _q, _r * _s}};
-        TensorView<1> dv{D, Dim<1>{_r * _s}};
-        TensorView<1> Fv{F, Dim<1>{_p * _q}};
+        TensorView gv{g, Dim<2>{_p * _q, _r * _s}};
+        TensorView dv{D, Dim<1>{_r * _s}};
+        TensorView Fv{F, Dim<1>{_p * _q}};
 
         linear_algebra::gemv<false>(2.0, gv, dv, 1.0, &Fv);
 
@@ -1733,18 +1733,18 @@ TEST_CASE("TensorView einsum") {
     using namespace einsums::tensor_algebra::index;
 
     // Test if everything passed to einsum is a TensorView.
-    Tensor<2> A = create_random_tensor("A", 3, 5);
-    Tensor<2> B = create_random_tensor("B", 3, 5);
-    TensorView<2> A_view{A, Dim<2>{3, 3}};
-    TensorView<2> B_view{B, Dim<2>{3, 3}, Offset<2>{0, 2}};
+    Tensor A = create_random_tensor("A", 3, 5);
+    Tensor B = create_random_tensor("B", 3, 5);
+    TensorView A_view{A, Dim<2>{3, 3}};
+    TensorView B_view{B, Dim<2>{3, 3}, Offset<2>{0, 2}};
 
-    Tensor<2> C{"C2", 10, 10};
+    Tensor C{"C2", 10, 10};
     C.zero();
-    TensorView<2> C_view{C, Dim<2>{3, 3}, Offset<2>{5, 5}};
+    TensorView C_view{C, Dim<2>{3, 3}, Offset<2>{5, 5}};
 
     // To perform the test we make an explicit copy of the TensorViews into their own Tensors
-    Tensor<2> A_copy{"A copy", 3, 3};
-    Tensor<2> B_copy{"B copy", 3, 3};
+    Tensor A_copy{"A copy", 3, 3};
+    Tensor B_copy{"B copy", 3, 3};
 
     for (int x = 0; x < 3; x++) {
         for (int y = 0; y < 3; y++) {
@@ -1754,7 +1754,7 @@ TEST_CASE("TensorView einsum") {
     }
 
     // The target solution is determined from not using views
-    Tensor<2> C_solution{"C solution", 3, 3};
+    Tensor C_solution{"C solution", 3, 3};
     C_solution.zero();
     REQUIRE_NOTHROW(einsum(Indices{i, j}, &C_solution, Indices{i, k}, A_copy, Indices{j, k}, B_copy));
 
@@ -1775,9 +1775,9 @@ TEST_CASE("outer product") {
     using namespace einsums::tensor_algebra::index;
 
     SECTION("1 * 1 -> 2") {
-        Tensor<1> A = create_random_tensor("A", 3);
-        Tensor<1> B = create_random_tensor("B", 3);
-        Tensor<2> C{"C", 3, 3};
+        Tensor A = create_random_tensor("A", 3);
+        Tensor B = create_random_tensor("B", 3);
+        Tensor C{"C", 3, 3};
         C.set_all(0.0);
 
         REQUIRE_NOTHROW(einsum(Indices{i, j}, &C, Indices{i}, A, Indices{j}, B));
@@ -1817,9 +1817,9 @@ TEST_CASE("outer product") {
     }
 
     SECTION("2 * 1 -> 3") {
-        Tensor<2> A = create_random_tensor("A", 3, 3);
-        Tensor<1> B = create_random_tensor("B", 3);
-        Tensor<3> C{"C", 3, 3, 3};
+        Tensor A = create_random_tensor("A", 3, 3);
+        Tensor B = create_random_tensor("B", 3);
+        Tensor C{"C", 3, 3, 3};
 
         C.set_all(0.0);
         REQUIRE_NOTHROW(einsum(Indices{i, j, k}, &C, Indices{i, j}, A, Indices{k}, B));
@@ -1856,9 +1856,9 @@ TEST_CASE("outer product") {
     }
 
     SECTION("2 * 2 -> 4") {
-        Tensor<2> A = create_random_tensor("A", 3, 3);
-        Tensor<2> B = create_random_tensor("B", 3, 3);
-        Tensor<4> C{"C", 3, 3, 3, 3};
+        Tensor A = create_random_tensor("A", 3, 3);
+        Tensor B = create_random_tensor("B", 3, 3);
+        Tensor C{"C", 3, 3, 3, 3};
 
         C.set_all(0.0);
         REQUIRE_NOTHROW(einsum(Indices{i, j, k, l}, &C, Indices{i, j}, A, Indices{k, l}, B));
@@ -1894,12 +1894,12 @@ TEST_CASE("view outer product") {
     using namespace einsums::tensor_algebra::index;
 
     SECTION("1 * 1 -> 2") {
-        Tensor<1> A = create_random_tensor("A", 6);
-        Tensor<1> B = create_random_tensor("B", 6);
+        Tensor A = create_random_tensor("A", 6);
+        Tensor B = create_random_tensor("B", 6);
 
-        auto vA = TensorView<1>(A, Dim<1>{3}, Offset<1>{3});
-        auto vB = TensorView<1>(B, Dim<1>{3});
-        Tensor<2> C{"C", 3, 3};
+        auto vA = TensorView(A, Dim<1>{3}, Offset<1>{3});
+        auto vB = TensorView(B, Dim<1>{3});
+        Tensor C{"C", 3, 3};
         C.set_all(0.0);
 
         REQUIRE_NOTHROW(einsum(Indices{i, j}, &C, Indices{i}, vA, Indices{j}, vB));
@@ -1939,11 +1939,11 @@ TEST_CASE("view outer product") {
     }
 
     SECTION("2 * 2 -> 4") {
-        Tensor<2> A = create_random_tensor("A", 9, 9);
-        Tensor<2> B = create_random_tensor("B", 12, 12);
+        Tensor A = create_random_tensor("A", 9, 9);
+        Tensor B = create_random_tensor("B", 12, 12);
         auto vA = TensorView{A, Dim<2>{3, 3}, Offset<2>{6, 3}};
         auto vB = TensorView{B, Dim<2>{3, 3}, Offset<2>{5, 7}};
-        Tensor<4> C{"C", 3, 3, 3, 3};
+        Tensor C{"C", 3, 3, 3, 3};
 
         C.set_all(0.0);
         REQUIRE_NOTHROW(einsum(Indices{i, j, k, l}, &C, Indices{i, j}, vA, Indices{k, l}, vB));
@@ -1979,8 +1979,8 @@ TEST_CASE("element transform") {
     using namespace einsums::tensor_algebra::index;
 
     SECTION("tensor") {
-        Tensor<4> A = create_random_tensor("A", 32, 32, 32, 32);
-        Tensor<4> Acopy = A;
+        Tensor A = create_random_tensor("A", 32, 32, 32, 32);
+        Tensor Acopy = A;
 
         element_transform(&A, [](double val) -> double { return 1.0 / val; });
 
@@ -1996,7 +1996,7 @@ TEST_CASE("element transform") {
     }
 
     SECTION("smartptr tensor") {
-        auto A = std::make_unique<Tensor<4>>("A", 32, 32, 32, 32);
+        auto A = std::make_unique<Tensor<double, 4>>("A", 32, 32, 32, 32);
 
         element_transform(&A, [](double val) -> double { return 1.0 / val; });
     }
@@ -2008,10 +2008,10 @@ TEST_CASE("element") {
     using namespace einsums::tensor_algebra::index;
 
     SECTION("1") {
-        Tensor<4> A = create_random_tensor("A", 10, 10, 10, 10);
-        Tensor<4> Acopy = A;
+        Tensor A = create_random_tensor("A", 10, 10, 10, 10);
+        Tensor Acopy = A;
 
-        Tensor<4> B = create_random_tensor("B", 10, 10, 10, 10);
+        Tensor B = create_random_tensor("B", 10, 10, 10, 10);
 
         element([](double const &Aval, double const &Bval) -> double { return Aval + Bval; }, &A, B);
 
@@ -2027,11 +2027,11 @@ TEST_CASE("element") {
     }
 
     SECTION("2") {
-        Tensor<4> A = create_random_tensor("A", 10, 10, 10, 10);
-        Tensor<4> Acopy = A;
+        Tensor A = create_random_tensor("A", 10, 10, 10, 10);
+        Tensor Acopy = A;
 
-        Tensor<4> B = create_random_tensor("B", 10, 10, 10, 10);
-        Tensor<4> C = create_random_tensor("C", 10, 10, 10, 10);
+        Tensor B = create_random_tensor("B", 10, 10, 10, 10);
+        Tensor C = create_random_tensor("C", 10, 10, 10, 10);
 
         element([](double const &Aval, double const &Bval, double const &Cval) -> double { return Aval + Bval + Cval; }, &A, B, C);
 
@@ -2048,11 +2048,11 @@ TEST_CASE("element") {
 
     // SECTION("2 - error") {
 
-    //     Tensor<4> A = create_random_tensor("A", 10, 10, 10, 10);
-    //     Tensor<4> Acopy = A;
+    //     Tensor A = create_random_tensor("A", 10, 10, 10, 10);
+    //     Tensor Acopy = A;
 
-    //     Tensor<4> B = create_random_tensor("B", 10, 10, 10, 9);
-    //     Tensor<4> C = create_random_tensor("C", 10, 10, 10, 10);
+    //     Tensor B = create_random_tensor("B", 10, 10, 10, 9);
+    //     Tensor C = create_random_tensor("C", 10, 10, 10, 10);
 
     //     element(
     //         &A, [](double const &Aval, double const &Bval, double const &Cval) -> double { return Aval + Bval + Cval; }, B, C);
@@ -2067,14 +2067,14 @@ TEST_CASE("einsum element") {
     const int _i{50}, _j{50};
 
     SECTION("1") {
-        Tensor<2> C = Tensor{"C", _i, _j};
-        Tensor<2> C0 = Tensor{"C", _i, _j};
+        Tensor C = Tensor{"C", _i, _j};
+        Tensor C0 = Tensor{"C", _i, _j};
 
         zero(C);
         zero(C0);
 
-        Tensor<2> B = create_random_tensor("B", _i, _j);
-        Tensor<2> A = create_random_tensor("A", _i, _j);
+        Tensor B = create_random_tensor("B", _i, _j);
+        Tensor A = create_random_tensor("A", _i, _j);
 
         element([](double const &Cval, double const &Aval, double const &Bval) -> double { return Aval * Bval; }, &C0, A, B);
 
@@ -2088,12 +2088,12 @@ TEST_CASE("einsum element") {
     }
 
     SECTION("2") {
-        Tensor<2> C = create_random_tensor("C", _i, _j);
-        Tensor<2> C0 = C;
-        Tensor<2> testresult{"result", _i, _j};
+        Tensor C = create_random_tensor("C", _i, _j);
+        Tensor C0 = C;
+        Tensor testresult{"result", _i, _j};
         zero(testresult);
 
-        Tensor<2> A = create_random_tensor("A", _i, _j);
+        Tensor A = create_random_tensor("A", _i, _j);
 
         element([](double const &Cval, double const &Aval) -> double { return Cval * Aval; }, &C, A);
 
@@ -2107,13 +2107,13 @@ TEST_CASE("einsum element") {
     }
 
     SECTION("3") {
-        Tensor<4> parentC = create_random_tensor("parentC", _i, _i, _i, _j);
-        Tensor<4> parentC0 = parentC;
-        Tensor<4> parentA = create_random_tensor("parentA", _i, _i, _i, _j);
+        Tensor parentC = create_random_tensor("parentC", _i, _i, _i, _j);
+        Tensor parentC0 = parentC;
+        Tensor parentA = create_random_tensor("parentA", _i, _i, _i, _j);
 
         auto C = parentC(3, All{}, All{}, 4);
         auto C0 = parentC0(3, All{}, All{}, 4);
-        Tensor<2> testresult{"result", _i, _j};
+        Tensor testresult{"result", _i, _j};
 
         for (int w = 0; w < _i; w++) {
             for (int x = 0; x < _j; x++) {
@@ -2147,12 +2147,12 @@ TEST_CASE("F12 - V term") {
     auto F = create_incremented_tensor("F", nall, nall, nall, nall);
     auto G = create_incremented_tensor("G", nall, nall, nall, nall);
 
-    TensorView<4> F_ooco{F, Dim<4>{nocc, nocc, ncabs, nocc}, Offset<4>{0, 0, nobs, 0}};
-    TensorView<4> F_oooc{F, Dim<4>{nocc, nocc, nocc, ncabs}, Offset<4>{0, 0, 0, nobs}};
-    TensorView<4> F_oopq{F, Dim<4>{nocc, nocc, nobs, nobs}, Offset<4>{0, 0, 0, 0}};
-    TensorView<4> G_ooco{G, Dim<4>{nocc, nocc, ncabs, nocc}, Offset<4>{0, 0, nobs, 0}};
-    TensorView<4> G_oooc{G, Dim<4>{nocc, nocc, nocc, ncabs}, Offset<4>{0, 0, 0, nobs}};
-    TensorView<4> G_oopq{G, Dim<4>{nocc, nocc, nobs, nobs}, Offset<4>{0, 0, 0, 0}};
+    TensorView F_ooco{F, Dim<4>{nocc, nocc, ncabs, nocc}, Offset<4>{0, 0, nobs, 0}};
+    TensorView F_oooc{F, Dim<4>{nocc, nocc, nocc, ncabs}, Offset<4>{0, 0, 0, nobs}};
+    TensorView F_oopq{F, Dim<4>{nocc, nocc, nobs, nobs}, Offset<4>{0, 0, 0, 0}};
+    TensorView G_ooco{G, Dim<4>{nocc, nocc, ncabs, nocc}, Offset<4>{0, 0, nobs, 0}};
+    TensorView G_oooc{G, Dim<4>{nocc, nocc, nocc, ncabs}, Offset<4>{0, 0, 0, nobs}};
+    TensorView G_oopq{G, Dim<4>{nocc, nocc, nobs, nobs}, Offset<4>{0, 0, 0, 0}};
 
     Tensor ijkl_1 = Tensor{"Einsum Temp 1", nocc, nocc, nocc, nocc};
     Tensor ijkl_2 = Tensor{"Einsum Temp 2", nocc, nocc, nocc, nocc};

--- a/timing/main.cpp
+++ b/timing/main.cpp
@@ -125,7 +125,7 @@ auto main() -> int {
     // Tensor<3> I_original = create_random_tensor("Original", size, size, size);
     // println(I_original);
 
-    // TensorView<2> I_view = I_original(d1, All{}, All{});
+    // TensorView<2> I_view = I_original(d1, All, All);
     // println(I_view);
 
     // for (size_t i = 0; i < size; i++) {
@@ -173,7 +173,7 @@ auto main() -> int {
 
     {
         Section section{"disk write"};
-        g(All{}, All{}, All{}, All{}) = eri;
+        g(All, All, All, All) = eri;
     }
     timer::report();
     blas::finalize();


### PR DESCRIPTION
Expands parts of the BLAS/LAPACK interface to support float, std::complex<float>, and std::complex<double> data types. In order to simply some of this interface, the order of the the template parameters to Tensor were changed from `<Rank, DataType>` to `<DataType, Rank>`. A helper function `create_tensor` was added to permit the automatic deduction of the value for `Rank` while specifying `DataType`. 

`einsum` was also expanded to support contractions between different datatypes. If the datatypes of the C, A, and B tensors are the same then BLAS will be used when possible; otherwise, the threaded generic algorithm will be used.